### PR TITLE
Various fixes and additions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -104,11 +104,17 @@ Native multi agents support:
 - [FIXED] issue https://github.com/Grid2op/grid2op/issues/657
 - [FIXED] missing an import on the `MaskedEnvironment` class
 - [FIXED] a bug when trying to set the load_p, load_q, gen_p, gen_v by names.
+- [FIXED] the `obs.get_forecast_env` : in some cases the resulting first
+  observation (obtained from `for_env.reset()`) did not have the correct
+  topology.
 - [ADDED] possibility to set the "thermal limits" when calling `env.reset(..., options={"thermal limit": xxx})`
 - [ADDED] possibility to retrieve some structural information about elements with
   with `gridobj.get_line_info(...)`, `gridobj.get_load_info(...)`, `gridobj.get_gen_info(...)` 
   or , `gridobj.get_storage_info(...)` 
 - [ADDED] codacy badge on the readme
+- [ADDED] a method to check the KCL (`obs.check_kirchoff`) directly from the observation
+  (previously it was only possible to do it from the backend). This should 
+  be used for testing purpose only
 - [IMPROVED] possibility to set the injections values with names
   to be consistent with other way to set the actions (*eg* set_bus)
 - [IMPROVED] error messages when creating an action which changes the injections
@@ -122,6 +128,8 @@ Native multi agents support:
 - [IMPROVED] the classes inherited from `GreedyAgent` with the added possibility to 
   do the `obs.simulate` on a different time horizon (kwarg `simulated_time_step`)
 - [IMPROVED] some type hints for some agent class
+- [IMPROVED] the `backend.update_from_obs` function to work even when observation
+  does not have shunt information but there are not shunts on the grid.
 
 [1.10.4] - 2024-10-15
 -------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -101,6 +101,8 @@ Native multi agents support:
 -----------------------
 - [BREAKING] Change for `FromMultiEpisodeData` that disables the caching by default
   when creating the data.
+- [BREAKING] deprecation of `backend.check_kirchoff` in favor of `backend.check_kirchhoff` 
+  (fix the typo in the name)
 - [FIXED] issue https://github.com/Grid2op/grid2op/issues/657
 - [FIXED] missing an import on the `MaskedEnvironment` class
 - [FIXED] a bug when trying to set the load_p, load_q, gen_p, gen_v by names.

--- a/grid2op/Backend/backend.py
+++ b/grid2op/Backend/backend.py
@@ -897,9 +897,9 @@ class Backend(GridObjects, ABC):
         If not implemented it returns empty list.
 
         Note that if there are shunt on the powergrid, it is recommended that this method should be implemented before
-        calling :func:`Backend.check_kirchoff`.
+        calling :func:`Backend.check_kirchhoff`.
 
-        If this method is implemented AND :func:`Backend.check_kirchoff` is called, the method
+        If this method is implemented AND :func:`Backend.check_kirchhoff` is called, the method
         :func:`Backend.sub_from_bus_id` should also be implemented preferably.
 
         Returns
@@ -1155,10 +1155,22 @@ class Backend(GridObjects, ABC):
 
     def check_kirchoff(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         """
+        .. versionchanged:: 1.11.0
+            Deprecated in favor of :attr:`Backend.check_kirchhoff` (no typo in the name this time)
+            
+        """
+        warnings.warn(message="please use backend.check_kirchhoff() instead", category=DeprecationWarning)
+        return self.check_kirchhoff()
+    
+    def check_kirchhoff(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """
         INTERNAL
 
         .. warning:: /!\\\\ Internal, do not use unless you know what you are doing /!\\\\
 
+        .. versionadded:: 1.11.0
+            Fix the typo of the :attr:`Backend.check_kirchoff` function
+            
         Check that the powergrid respects kirchhoff's law.
         This function can be called at any moment (after a powerflow has been run)
         to make sure a powergrid is in a consistent state, or to perform
@@ -1402,7 +1414,7 @@ class Backend(GridObjects, ABC):
                 )
         else:
             warnings.warn(
-                "Backend.check_kirchoff Impossible to get shunt information. Reactive information might be "
+                "Backend.check_kirchhoff Impossible to get shunt information. Reactive information might be "
                 "incorrect."
             )
         diff_v_bus = np.zeros((cls.n_sub, cls.n_busbar_per_sub), dtype=dt_float)

--- a/grid2op/Backend/backend.py
+++ b/grid2op/Backend/backend.py
@@ -2027,7 +2027,7 @@ class Backend(GridObjects, ABC):
         }
 
         if cls.shunts_data_available and type(obs).shunts_data_available:
-            if "_shunt_bus" not in type(obs).attr_list_set:
+            if cls.n_shunt > 0 and "_shunt_bus" not in type(obs).attr_list_set:
                 raise BackendError(
                     "Impossible to set the backend to the state given by the observation: shunts data "
                     "are not present in the observation."

--- a/grid2op/Environment/environment.py
+++ b/grid2op/Environment/environment.py
@@ -947,6 +947,10 @@ class Environment(BaseEnv):
 
         self._backend_action = self._backend_action_class()
         self.nb_time_step = -1  # to have init obs at step 1 (and to prevent 'setting to proper state' "action" to be illegal)
+        
+        if self._init_obs is not None:
+            self.backend.update_from_obs(self._init_obs)
+            
         init_action = None
         if not self._parameters.IGNORE_INITIAL_STATE_TIME_SERIE:
             # load the initial state from the time series (default)
@@ -1293,7 +1297,6 @@ class Environment(BaseEnv):
             if ambiguous:
                 raise Grid2OpException("You provided an invalid (ambiguous) action to set the 'init state'") from except_tmp
             init_state.remove_change()
-        
         super().reset(seed=seed, options=options)
         
         if options is not None and "max step" in options:                

--- a/grid2op/Observation/baseObservation.py
+++ b/grid2op/Observation/baseObservation.py
@@ -4845,3 +4845,174 @@ class BaseObservation(GridObjects):
         if self._is_done:
             raise Grid2OpException("Cannot use this function in a 'done' state.")
         return self.action_helper.get_back_to_ref_state(self, storage_setpoint, precision)
+
+    def _aux_kcl(self,
+                 n_el, # cst eg. cls.n_gen
+                 el_to_subid, # cst eg. cls.gen_to_subid
+                 el_bus,  # cst eg. gen_bus
+                 el_p,  # cst, eg. gen_p
+                 el_q,  # cst, eg. gen_q
+                 el_v,  # cst, eg. gen_v
+                 p_subs, q_subs,
+                 p_bus, q_bus,
+                 v_bus,
+                 load_conv=True  # whether the object is load convention (True) or gen convention (False)
+                 ):
+        
+        # bellow i'm "forced" to do a loop otherwise, numpy do not compute the "+=" the way I want it to.
+        # for example, if two powerlines are such that line_or_to_subid is equal (eg both connected to substation 0)
+        # then numpy do not guarantee that `p_subs[self.line_or_to_subid] += p_or` will add the two "corresponding p_or"
+        # TODO this can be vectorized with matrix product, see example in obs.flow_bus_matrix (BaseObervation.py)
+        for i in range(n_el):
+            psubid = el_to_subid[i]
+            if el_bus[i] == -1:
+                # el is disconnected
+                continue
+            
+            # for substations
+            if load_conv:
+                p_subs[psubid] += el_p[i]
+                q_subs[psubid] += el_q[i]
+            else:
+                p_subs[psubid] -= el_p[i]
+                q_subs[psubid] -= el_q[i]
+
+            # for bus
+            loc_bus = el_bus[i] - 1
+            if load_conv:
+                p_bus[psubid, loc_bus] += el_p[i]
+                q_bus[psubid, loc_bus] += el_q[i]
+            else:
+                p_bus[psubid, loc_bus] -= el_p[i]
+                q_bus[psubid, loc_bus] -= el_q[i]
+
+            # compute max and min values
+            if el_v[i]:
+                # but only if gen is connected
+                v_bus[psubid, loc_bus][0] = min(
+                    v_bus[psubid, loc_bus][0],
+                    el_v[i],
+                )
+                v_bus[psubid, loc_bus][1] = max(
+                    v_bus[psubid, loc_bus][1],
+                    el_v[i],
+                )
+                
+    def check_kirchoff(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """
+        Analogous to "backend.check_kirchoff" but from the observation
+
+        .. versionadded:: 1.11.0
+        
+        Returns
+        -------
+        p_subs ``numpy.ndarray``
+            sum of injected active power at each substations (MW)
+        q_subs ``numpy.ndarray``
+            sum of injected reactive power at each substations (MVAr)
+        p_bus ``numpy.ndarray``
+            sum of injected active power at each buses. It is given in form of a matrix, with number of substations as
+            row, and number of columns equal to the maximum number of buses for a substation (MW)
+        q_bus ``numpy.ndarray``
+            sum of injected reactive power at each buses. It is given in form of a matrix, with number of substations as
+            row, and number of columns equal to the maximum number of buses for a substation (MVAr)
+        diff_v_bus: ``numpy.ndarray`` (2d array)
+            difference between maximum voltage and minimum voltage (computed for each elements)
+            at each bus. It is an array of two dimension:
+
+            - first dimension represents the the substation (between 1 and self.n_sub)
+            - second element represents the busbar in the substation (0 or 1 usually)
+
+        """
+        cls = type(self)
+        
+        # fist check the "substation law" : nothing is created at any substation
+        p_subs = np.zeros(cls.n_sub, dtype=dt_float)
+        q_subs = np.zeros(cls.n_sub, dtype=dt_float)
+
+        # check for each bus
+        p_bus = np.zeros((cls.n_sub, cls.n_busbar_per_sub), dtype=dt_float)
+        q_bus = np.zeros((cls.n_sub, cls.n_busbar_per_sub), dtype=dt_float)
+        v_bus = (
+            np.zeros((cls.n_sub, cls.n_busbar_per_sub, 2), dtype=dt_float) - 1.0
+        )  # sub, busbar, [min,max]
+
+        self._aux_kcl(
+            cls.n_line, # cst eg. cls.n_gen
+            cls.line_or_to_subid, # cst eg. cls.gen_to_subid
+            self.line_or_bus,
+            self.p_or,  # cst, eg. gen_p
+            self.q_or,  # cst, eg. gen_q
+            self.v_or,  # cst, eg. gen_v
+            p_subs, q_subs,
+            p_bus, q_bus,
+            v_bus,
+            )
+        self._aux_kcl(
+            cls.n_line, # cst eg. cls.n_gen
+            cls.line_ex_to_subid, # cst eg. cls.gen_to_subid
+            self.line_ex_bus,
+            self.p_ex,  # cst, eg. gen_p
+            self.q_ex,  # cst, eg. gen_q
+            self.v_ex,  # cst, eg. gen_v
+            p_subs, q_subs,
+            p_bus, q_bus,
+            v_bus,
+            )
+        self._aux_kcl(
+            cls.n_load, # cst eg. cls.n_gen
+            cls.load_to_subid, # cst eg. cls.gen_to_subid
+            self.load_bus,
+            self.load_p,  # cst, eg. gen_p
+            self.load_q,  # cst, eg. gen_q
+            self.load_v,  # cst, eg. gen_v
+            p_subs, q_subs,
+            p_bus, q_bus,
+            v_bus,
+            )
+        self._aux_kcl(
+            cls.n_gen, # cst eg. cls.n_gen
+            cls.gen_to_subid, # cst eg. cls.gen_to_subid
+            self.gen_bus,  # cst eg. self.gen_bus
+            self.gen_p,  # cst, eg. gen_p
+            self.gen_q,  # cst, eg. gen_q
+            self.gen_v,  # cst, eg. gen_v
+            p_subs, q_subs,
+            p_bus, q_bus,
+            v_bus,
+            load_conv=False
+            )
+        if cls.n_storage:
+            self._aux_kcl(
+                cls.n_storage, # cst eg. cls.n_gen
+                cls.storage_to_subid, # cst eg. cls.gen_to_subid
+                self.storage_bus,
+                self.storage_p,  # cst, eg. gen_p
+                self.storage_q,  # cst, eg. gen_q
+                self.storage_v,  # cst, eg. gen_v
+                p_subs, q_subs,
+                p_bus, q_bus,
+                v_bus,
+                )
+
+        if cls.shunts_data_available:
+            self._aux_kcl(
+                cls.n_shunt, # cst eg. cls.n_gen
+                cls.storage_to_subid, # cst eg. cls.gen_to_subid
+                self._shunt_bus,
+                self._shunt_p,  # cst, eg. gen_p
+                self._shunt_q,  # cst, eg. gen_q
+                self._shunt_v,  # cst, eg. gen_v
+                p_subs, q_subs,
+                p_bus, q_bus,
+                v_bus,
+                )
+        else:
+            warnings.warn(
+                "Observation.check_kirchoff Impossible to get shunt information. Reactive information might be "
+                "incorrect."
+            )
+        diff_v_bus = np.zeros((cls.n_sub, cls.n_busbar_per_sub), dtype=dt_float)
+        diff_v_bus[:, :] = v_bus[:, :, 1] - v_bus[:, :, 0]
+        return p_subs, q_subs, p_bus, q_bus, diff_v_bus
+    

--- a/grid2op/tests/BaseBackendTest.py
+++ b/grid2op/tests/BaseBackendTest.py
@@ -183,7 +183,7 @@ class BaseTestLoadingCase(MakeBackend):
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
-            p_subs, q_subs, p_bus, q_bus, v_bus = backend.check_kirchoff()
+            p_subs, q_subs, p_bus, q_bus, v_bus = backend.check_kirchhoff()
 
         assert np.max(np.abs(p_subs)) <= self.tolvect
         assert np.max(np.abs(p_bus.flatten())) <= self.tolvect
@@ -659,15 +659,15 @@ class BaseTestLoadingBackendFunc(MakeBackend):
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
-            p_subs, q_subs, p_bus, q_bus, v_bus = self.backend.check_kirchoff()
+            p_subs, q_subs, p_bus, q_bus, v_bus = self.backend.check_kirchhoff()
 
         # i'm in DC mode, i can't check for reactive values...
         assert (
             np.max(np.abs(p_subs)) <= self.tolvect
-        ), "problem with active values, at substation (kirchoff for DC)"
+        ), "problem with active values, at substation (Kirchhoff for DC)"
         assert (
             np.max(np.abs(p_bus.flatten())) <= self.tolvect
-        ), "problem with active values, at a bus (kirchoff for DC)"
+        ), "problem with active values, at a bus (Kirchhoff for DC)"
 
         assert self.compare_vect(
             new_pp, after_gp
@@ -846,10 +846,10 @@ class BaseTestTopoAction(MakeBackend):
     def compare_vect(self, pred, true):
         return np.max(np.abs(pred - true)) <= self.tolvect
 
-    def _check_kirchoff(self):
+    def _check_kirchhoff(self):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
-            p_subs, q_subs, p_bus, q_bus, v_bus = self.backend.check_kirchoff()
+            p_subs, q_subs, p_bus, q_bus, v_bus = self.backend.check_kirchhoff()
             assert (
                 np.max(np.abs(p_subs)) <= self.tolvect
             ), "problem with active values, at substation"
@@ -1043,7 +1043,7 @@ class BaseTestTopoAction(MakeBackend):
             ]
         )
         assert self.compare_vect(after_amps_flow, after_amps_flow_th)
-        self._check_kirchoff()
+        self._check_kirchhoff()
 
     def test_topo_change1sub(self):
         # check that switching the bus of 3 object is equivalent to set them to bus 2 (as above)
@@ -1117,7 +1117,7 @@ class BaseTestTopoAction(MakeBackend):
             ]
         )
         assert self.compare_vect(after_amps_flow, after_amps_flow_th)
-        self._check_kirchoff()
+        self._check_kirchhoff()
 
     def test_topo_change_1sub_twice(self):
         # check that switching the bus of 3 object is equivalent to set them to bus 2 (as above)
@@ -1192,7 +1192,7 @@ class BaseTestTopoAction(MakeBackend):
             ]
         )
         assert self.compare_vect(after_amps_flow, after_amps_flow_th)
-        self._check_kirchoff()
+        self._check_kirchhoff()
 
         action = self.helper_action({"change_bus": {"substations_id": [(id_, arr)]}})
         bk_action += action
@@ -1207,7 +1207,7 @@ class BaseTestTopoAction(MakeBackend):
         topo_vect = self.backend.get_topo_vect()
         assert np.min(topo_vect) == 1
         assert np.max(topo_vect) == 1
-        self._check_kirchoff()
+        self._check_kirchhoff()
 
     def test_topo_change_2sub(self):
         # check that maintenance vector is properly taken into account
@@ -1305,7 +1305,7 @@ class BaseTestTopoAction(MakeBackend):
             ]
         )
         assert self.compare_vect(after_amps_flow, after_amps_flow_th)
-        self._check_kirchoff()
+        self._check_kirchhoff()
 
     def _aux_test_back_orig(self, act_set, prod_p, load_p, p_or, sh_q):
         """function used for test_get_action_to_set"""
@@ -2413,16 +2413,16 @@ class BaseTestChangeBusSlack(MakeBackend):
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
-            p_subs, q_subs, p_bus, q_bus, v_bus = env.backend.check_kirchoff()
+            p_subs, q_subs, p_bus, q_bus, v_bus = env.backend.check_kirchhoff()
         assert np.all(np.abs(p_subs) <= self.tol_one)
         assert np.all(np.abs(p_bus) <= self.tol_one)
 
 
 class BaseTestStorageAction(MakeBackend):
-    def _aux_test_kirchoff(self):
+    def _aux_test_kirchhoff(self):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
-            p_subs, q_subs, p_bus, q_bus, diff_v_bus = self.env.backend.check_kirchoff()
+            p_subs, q_subs, p_bus, q_bus, diff_v_bus = self.env.backend.check_kirchhoff()
         assert np.all(
             np.abs(p_subs) <= self.tol_one
         ), "error with active value at some substations"
@@ -2461,7 +2461,7 @@ class BaseTestStorageAction(MakeBackend):
         storage_p, storage_q, storage_v = self.env.backend.storages_info()
         assert np.all(np.abs(storage_p - array_modif) <= self.tol_one)
         assert np.all(np.abs(storage_q - 0.0) <= self.tol_one)
-        self._aux_test_kirchoff()
+        self._aux_test_kirchhoff()
 
         array_modif = np.array([2, 8], dtype=dt_float)
         act = self.env.action_space({"set_storage": array_modif})
@@ -2470,7 +2470,7 @@ class BaseTestStorageAction(MakeBackend):
         storage_p, storage_q, storage_v = self.env.backend.storages_info()
         assert np.all(np.abs(storage_p - array_modif) <= self.tol_one)
         assert np.all(np.abs(storage_q - 0.0) <= self.tol_one)
-        self._aux_test_kirchoff()
+        self._aux_test_kirchhoff()
 
         # illegal action
         array_modif = np.array([2, 12], dtype=dt_float)
@@ -2480,7 +2480,7 @@ class BaseTestStorageAction(MakeBackend):
         storage_p, storage_q, storage_v = self.env.backend.storages_info()
         assert np.all(np.abs(storage_p - [0.0, 0.0]) <= self.tol_one)
         assert np.all(np.abs(storage_q - 0.0) <= self.tol_one)
-        self._aux_test_kirchoff()
+        self._aux_test_kirchhoff()
 
         # full discharge now
         array_modif = np.array([-1.5, -10.0], dtype=dt_float)
@@ -2495,7 +2495,7 @@ class BaseTestStorageAction(MakeBackend):
             assert np.all(
                 np.abs(storage_q - 0.0) <= self.tol_one
             ), f"error for Q for time step {nb_ts}"
-            self._aux_test_kirchoff()
+            self._aux_test_kirchhoff()
 
         obs, reward, done, info = self.env.step(act)
         assert not info["exception"]
@@ -2503,7 +2503,7 @@ class BaseTestStorageAction(MakeBackend):
         storage_p, *_ = self.env.backend.storages_info()
         assert np.all(np.abs(storage_p - [-1.5, -4.4599934]) <= self.tol_one)
         assert np.all(np.abs(obs.storage_charge[1] - 0.0) <= self.tol_one)
-        self._aux_test_kirchoff()
+        self._aux_test_kirchhoff()
 
         obs, reward, done, info = self.env.step(act)
         assert not info["exception"]
@@ -2511,7 +2511,7 @@ class BaseTestStorageAction(MakeBackend):
         storage_p, *_ = self.env.backend.storages_info()
         assert np.all(np.abs(storage_p - [-1.5, 0.0]) <= self.tol_one)
         assert np.all(np.abs(obs.storage_charge[1] - 0.0) <= self.tol_one)
-        self._aux_test_kirchoff()
+        self._aux_test_kirchhoff()
 
     def test_storage_action_topo(self):
         """test the modification of the bus of a storage unit"""
@@ -2564,7 +2564,7 @@ class BaseTestStorageAction(MakeBackend):
         assert obs.storage_bus[0] == 2
         assert obs.line_or_bus[8] == 2
         assert obs.gen_bus[3] == 2
-        self._aux_test_kirchoff()
+        self._aux_test_kirchhoff()
 
         # second case, still standard modification (set to orig)
         array_modif = np.array([1.5, 10.0], dtype=dt_float)
@@ -2586,7 +2586,7 @@ class BaseTestStorageAction(MakeBackend):
         assert obs.storage_bus[0] == 1
         assert obs.line_or_bus[8] == 1
         assert obs.gen_bus[3] == 1
-        self._aux_test_kirchoff()
+        self._aux_test_kirchhoff()
 
         # fourth case: isolated storage on a busbar (so it is disconnected, but with 0. production => so thats fine)
         array_modif = np.array([0.0, 7.0], dtype=dt_float)
@@ -2619,7 +2619,7 @@ class BaseTestStorageAction(MakeBackend):
         # assert storage_v[0] == 0.0, "storage 0 should be disconnected"
         # assert obs.line_or_bus[8] == 1
         # assert obs.gen_bus[3] == 1
-        # self._aux_test_kirchoff()
+        # self._aux_test_kirchhoff()
 
         # check that if i don't touch it it's set to 0
         # act = self.env.action_space()
@@ -2636,7 +2636,7 @@ class BaseTestStorageAction(MakeBackend):
         # assert storage_v[0] == 0.0, "storage 0 should be disconnected"
         # assert obs.line_or_bus[8] == 1
         # assert obs.gen_bus[3] == 1
-        # self._aux_test_kirchoff()
+        # self._aux_test_kirchhoff()
 
         # # trying to act on a disconnected storage => illegal)
         # array_modif = np.array([2.0, 7.0], dtype=dt_float)
@@ -2644,7 +2644,7 @@ class BaseTestStorageAction(MakeBackend):
         # obs, reward, done, info = self.env.step(act)
         # assert info["exception"]  # action should be illegal
         # assert not done  # this is fine, as it's illegal it's replaced by do nothing
-        # self._aux_test_kirchoff()
+        # self._aux_test_kirchhoff()
 
         # # trying to reconnect a storage alone on a bus => game over, not connected bus
         # array_modif = np.array([1.0, 7.0], dtype=dt_float)

--- a/grid2op/tests/aaa_test_backend_interface.py
+++ b/grid2op/tests/aaa_test_backend_interface.py
@@ -667,11 +667,11 @@ class AAATestBackendAPI(MakeBackend):
         if not cls.shunts_data_available:
             warnings.warn(f"{type(self).__name__} test_14change_topology: This test is not performed in depth as your backend does not support shunts")
         else:
-            p_subs, q_subs, p_bus, q_bus, diff_v_bus = backend.check_kirchoff()
-            assert np.allclose(p_subs, 0., atol=3 * self.tol_one), "there are some discrepency in the backend after a powerflow (no modif): kirchoff laws are not met for p (creation or suppression of active). Check the handling of the slack bus(se) maybe ?"
-            assert np.allclose(q_subs, 0., atol=3 * self.tol_one), "there are some discrepency in the backend after a powerflow (no modif): kirchoff laws are not met for q (creation or suppression of reactive). Check the handling of the slack bus(se) maybe ?"
-            assert np.allclose(p_bus, 0., atol=3 * self.tol_one), "there are some discrepency in the backend after a powerflow (no modif): kirchoff laws are not met for p (creation or suppression of active). Check the handling of the slack bus(se) maybe ?"
-            assert np.allclose(q_bus, 0., atol=3 * self.tol_one), "there are some discrepency in the backend after a powerflow (no modif): kirchoff laws are not met for q (creation or suppression of reactive). Check the handling of the slack bus(se) maybe ?"
+            p_subs, q_subs, p_bus, q_bus, diff_v_bus = backend.check_kirchhoff()
+            assert np.allclose(p_subs, 0., atol=3 * self.tol_one), "there are some discrepency in the backend after a powerflow (no modif): Kirchhoff laws are not met for p (creation or suppression of active). Check the handling of the slack bus(se) maybe ?"
+            assert np.allclose(q_subs, 0., atol=3 * self.tol_one), "there are some discrepency in the backend after a powerflow (no modif): Kirchhoff laws are not met for q (creation or suppression of reactive). Check the handling of the slack bus(se) maybe ?"
+            assert np.allclose(p_bus, 0., atol=3 * self.tol_one), "there are some discrepency in the backend after a powerflow (no modif): Kirchhoff laws are not met for p (creation or suppression of active). Check the handling of the slack bus(se) maybe ?"
+            assert np.allclose(q_bus, 0., atol=3 * self.tol_one), "there are some discrepency in the backend after a powerflow (no modif): Kirchhoff laws are not met for q (creation or suppression of reactive). Check the handling of the slack bus(se) maybe ?"
             assert np.allclose(diff_v_bus, 0., atol=3 * self.tol_one), "there are some discrepency in the backend after a powerflow (no modif): some nodes have two different voltages. Check the accessor for voltage in all the `***_info()` (*eg* `loads_info()`)"
             
         p_or, q_or, v_or, a_or = backend.lines_or_info()
@@ -690,11 +690,11 @@ class AAATestBackendAPI(MakeBackend):
         if not cls.shunts_data_available:
             warnings.warn(f"{type(self).__name__} test_14change_topology: This test is not performed in depth as your backend does not support shunts")
         else:
-            p_subs, q_subs, p_bus, q_bus, diff_v_bus = backend.check_kirchoff()
-            assert np.allclose(p_subs, 0., atol=3 * self.tol_one), "there are some discrepency in the backend after a powerflow (modif with no impact): kirchoff laws are not met for p (creation or suppression of active)."
-            assert np.allclose(q_subs, 0., atol=3 * self.tol_one), "there are some discrepency in the backend after a powerflow (modif with no impact): kirchoff laws are not met for q (creation or suppression of reactive)."
-            assert np.allclose(p_bus, 0., atol=3 * self.tol_one), "there are some discrepency in the backend after a powerflow (modif with no impact): kirchoff laws are not met for p (creation or suppression of active)."
-            assert np.allclose(q_bus, 0., atol=3 * self.tol_one), "there are some discrepency in the backend after a powerflow (modif with no impact): kirchoff laws are not met for q (creation or suppression of reactive)."
+            p_subs, q_subs, p_bus, q_bus, diff_v_bus = backend.check_kirchhoff()
+            assert np.allclose(p_subs, 0., atol=3 * self.tol_one), "there are some discrepency in the backend after a powerflow (modif with no impact): Kirchhoff laws are not met for p (creation or suppression of active)."
+            assert np.allclose(q_subs, 0., atol=3 * self.tol_one), "there are some discrepency in the backend after a powerflow (modif with no impact): Kirchhoff laws are not met for q (creation or suppression of reactive)."
+            assert np.allclose(p_bus, 0., atol=3 * self.tol_one), "there are some discrepency in the backend after a powerflow (modif with no impact): Kirchhoff laws are not met for p (creation or suppression of active)."
+            assert np.allclose(q_bus, 0., atol=3 * self.tol_one), "there are some discrepency in the backend after a powerflow (modif with no impact): Kirchhoff laws are not met for q (creation or suppression of reactive)."
             assert np.allclose(diff_v_bus, 0., atol=3 * self.tol_one), "there are some discrepency in the backend after a powerflow: some nodes have two different voltages. Check the accessor for voltage in all the `***_info()` (*eg* `loads_info()`)"
         
         p_after_or, q_after_or, v_after_or, a_after_or = backend.lines_or_info()
@@ -716,11 +716,11 @@ class AAATestBackendAPI(MakeBackend):
         if not cls.shunts_data_available:
             warnings.warn(f"{type(self).__name__} test_14change_topology: This test is not performed in depth as your backend does not support shunts")
         else:
-            p_subs, q_subs, p_bus, q_bus, diff_v_bus = backend.check_kirchoff()
-            assert np.allclose(p_subs, 0., atol=3 * self.tol_one), "there are some discrepency in the backend after a powerflow (modif with a real impact): kirchoff laws are not met for p (creation or suppression of active)."
-            assert np.allclose(q_subs, 0., atol=3 * self.tol_one), "there are some discrepency in the backend after a powerflow (modif with a real impact): kirchoff laws are not met for q (creation or suppression of reactive)."
-            assert np.allclose(p_bus, 0., atol=3 * self.tol_one), "there are some discrepency in the backend after a powerflow (modif with a real impact): kirchoff laws are not met for p (creation or suppression of active)."
-            assert np.allclose(q_bus, 0., atol=3 * self.tol_one), "there are some discrepency in the backend after a powerflow (modif with a real impact): kirchoff laws are not met for q (creation or suppression of reactive)."
+            p_subs, q_subs, p_bus, q_bus, diff_v_bus = backend.check_kirchhoff()
+            assert np.allclose(p_subs, 0., atol=3 * self.tol_one), "there are some discrepency in the backend after a powerflow (modif with a real impact): Kirchhoff laws are not met for p (creation or suppression of active)."
+            assert np.allclose(q_subs, 0., atol=3 * self.tol_one), "there are some discrepency in the backend after a powerflow (modif with a real impact): Kirchhoff laws are not met for q (creation or suppression of reactive)."
+            assert np.allclose(p_bus, 0., atol=3 * self.tol_one), "there are some discrepency in the backend after a powerflow (modif with a real impact): Kirchhoff laws are not met for p (creation or suppression of active)."
+            assert np.allclose(q_bus, 0., atol=3 * self.tol_one), "there are some discrepency in the backend after a powerflow (modif with a real impact): Kirchhoff laws are not met for q (creation or suppression of reactive)."
             assert np.allclose(diff_v_bus, 0., atol=3 * self.tol_one), "there are some discrepency in the backend after a powerflow: some nodes have two different voltages. Check the accessor for voltage in all the `***_info()` (*eg* `loads_info()`)"
         
         p_after_or, q_after_or, v_after_or, a_after_or = backend.lines_or_info()

--- a/grid2op/tests/test_Observation.py
+++ b/grid2op/tests/test_Observation.py
@@ -1100,8 +1100,8 @@ class TestBasisObsBehaviour(unittest.TestCase):
                 else:
                     p_line += graph.edges[(k1, k2)]["p_ex"]
                     q_line += graph.edges[(k1, k2)]["q_ex"]
-            assert abs(p_line - p_) <= 1e-5, "error for kirchoff's law for graph for P"
-            assert abs(q_line - q_) <= 1e-5, "error for kirchoff's law for graph for Q"
+            assert abs(p_line - p_) <= 1e-5, "error for Kirchhoff's law for graph for P"
+            assert abs(q_line - q_) <= 1e-5, "error for Kirchhoff's law for graph for Q"
 
     def test_bus_conn_mat_csr(self):
         self.aux_test_bus_conn_mat(as_csr=True)
@@ -1863,7 +1863,7 @@ class TestBasisObsBehaviour(unittest.TestCase):
         assert mat.shape == (15, 15)
         assert ind_lor[7] == 14
         assert ind_lor[8] == 14
-        # check that kirchoff law is met
+        # check that Kirchhoff law is met
         if active_flow:
             assert np.max(np.abs(mat.sum(axis=1))) <= self.tol_one
             assert np.abs(mat[0, 0] - obs.prod_p[-1]) <= self.tol_one
@@ -1888,7 +1888,7 @@ class TestBasisObsBehaviour(unittest.TestCase):
         assert ind_lor[8] == 15
         assert ind_lor[2] == 14
         assert ind_lex[0] == 14
-        # check that kirchoff law is met
+        # check that Kirchhoff law is met
         if active_flow:
             assert np.max(np.abs(mat.sum(axis=1))) <= self.tol_one
             assert np.abs(mat[0, 0] - obs.prod_p[-1]) <= self.tol_one
@@ -1952,7 +1952,7 @@ class TestBasisObsBehaviour(unittest.TestCase):
         assert mat.shape == (15, 15)
         assert ind_lor[7] == 14
         assert ind_lor[8] == 14
-        # check that kirchoff law is met
+        # check that Kirchhoff law is met
         if active_flow:
             assert np.max(np.abs(mat.sum(axis=1))) <= self.tol_one
             assert np.abs(mat[0, 0] - obs.prod_p[-1]) <= self.tol_one
@@ -1982,7 +1982,7 @@ class TestBasisObsBehaviour(unittest.TestCase):
         assert ind_lor[8] == 15
         assert ind_lor[2] == 14
         assert ind_lex[0] == 14
-        # check that kirchoff law is met
+        # check that Kirchhoff law is met
         assert np.max(np.abs(mat.sum(axis=1))) <= self.tol_one
         if active_flow:
             assert np.abs(mat[0, 0] - obs.prod_p[-1]) <= self.tol_one

--- a/grid2op/tests/test_Storage.py
+++ b/grid2op/tests/test_Storage.py
@@ -730,8 +730,8 @@ class TestStorageEnv(HelperTests, unittest.TestCase):
             <= self.tol_one
         )
 
-    def _aux_test_kirchoff(self):
-        p_subs, q_subs, p_bus, q_bus, diff_v_bus = self.env.backend.check_kirchoff()
+    def _aux_test_kirchhoff(self):
+        p_subs, q_subs, p_bus, q_bus, diff_v_bus = self.env.backend.check_kirchhoff()
         assert np.all(
             np.abs(p_subs) <= self.tol_one
         ), "error with active value at some substations"
@@ -755,7 +755,7 @@ class TestStorageEnv(HelperTests, unittest.TestCase):
         storage_p, storage_q, storage_v = self.env.backend.storages_info()
         assert np.all(np.abs(storage_p - array_modif) <= self.tol_one)
         assert np.all(np.abs(storage_q - 0.0) <= self.tol_one)
-        self._aux_test_kirchoff()
+        self._aux_test_kirchhoff()
 
         array_modif = np.array([2, 8], dtype=dt_float)
         act = self.env.action_space({"set_storage": array_modif})
@@ -764,7 +764,7 @@ class TestStorageEnv(HelperTests, unittest.TestCase):
         storage_p, storage_q, storage_v = self.env.backend.storages_info()
         assert np.all(np.abs(storage_p - array_modif) <= self.tol_one)
         assert np.all(np.abs(storage_q - 0.0) <= self.tol_one)
-        self._aux_test_kirchoff()
+        self._aux_test_kirchhoff()
 
         # illegal action
         array_modif = np.array([2, 12], dtype=dt_float)
@@ -774,7 +774,7 @@ class TestStorageEnv(HelperTests, unittest.TestCase):
         storage_p, storage_q, storage_v = self.env.backend.storages_info()
         assert np.all(np.abs(storage_p - [0.0, 0.0]) <= self.tol_one)
         assert np.all(np.abs(storage_q - 0.0) <= self.tol_one)
-        self._aux_test_kirchoff()
+        self._aux_test_kirchhoff()
 
         # full discharge now
         array_modif = np.array([-1.5, -10.0], dtype=dt_float)
@@ -789,7 +789,7 @@ class TestStorageEnv(HelperTests, unittest.TestCase):
             assert np.all(
                 np.abs(storage_q - 0.0) <= self.tol_one
             ), f"error for Q for time step {nb_ts}"
-            self._aux_test_kirchoff()
+            self._aux_test_kirchhoff()
 
         obs, reward, done, info = self.env.step(act)
         assert not info["exception"]
@@ -799,7 +799,7 @@ class TestStorageEnv(HelperTests, unittest.TestCase):
             <= self.tol_one
         )
         assert np.all(np.abs(obs.storage_charge[1] - 0.0) <= self.tol_one)
-        self._aux_test_kirchoff()
+        self._aux_test_kirchhoff()
 
         obs, reward, done, info = self.env.step(act)
         assert not info["exception"]
@@ -809,7 +809,7 @@ class TestStorageEnv(HelperTests, unittest.TestCase):
             <= self.tol_one
         )
         assert np.all(np.abs(obs.storage_charge[1] - 0.0) <= self.tol_one)
-        self._aux_test_kirchoff()
+        self._aux_test_kirchhoff()
 
     def test_storage_action_topo(self):
         """test the modification of the bus of a storage unit"""
@@ -850,7 +850,7 @@ class TestStorageEnv(HelperTests, unittest.TestCase):
         assert obs.storage_bus[0] == 2
         assert obs.line_or_bus[8] == 2
         assert obs.gen_bus[3] == 2
-        self._aux_test_kirchoff()
+        self._aux_test_kirchhoff()
 
         # second case, still standard modification (set to orig)
         array_modif = np.array([1.5, 10.0], dtype=dt_float)
@@ -872,7 +872,7 @@ class TestStorageEnv(HelperTests, unittest.TestCase):
         assert obs.storage_bus[0] == 1
         assert obs.line_or_bus[8] == 1
         assert obs.gen_bus[3] == 1
-        self._aux_test_kirchoff()
+        self._aux_test_kirchhoff()
 
         # THIS IS EXPECTED THAT IT DOES NOT PASS FROM GRID2OP 1.9.6 !
         # fourth case: isolated storage on a busbar (so it is disconnected, but with 0. production => so thats fine)
@@ -898,7 +898,7 @@ class TestStorageEnv(HelperTests, unittest.TestCase):
         # assert storage_v[0] == 0.0, "storage 0 should be disconnected"
         # assert obs.line_or_bus[8] == 1
         # assert obs.gen_bus[3] == 1
-        # self._aux_test_kirchoff()
+        # self._aux_test_kirchhoff()
 
         # # check that if i don't touch it it's set to 0
         # act = self.env.action_space()
@@ -915,7 +915,7 @@ class TestStorageEnv(HelperTests, unittest.TestCase):
         # assert storage_v[0] == 0.0, "storage 0 should be disconnected"
         # assert obs.line_or_bus[8] == 1
         # assert obs.gen_bus[3] == 1
-        # self._aux_test_kirchoff()
+        # self._aux_test_kirchhoff()
 
         # # trying to act on a disconnected storage => illegal)
         # array_modif = np.array([2.0, 7.0], dtype=dt_float)
@@ -923,7 +923,7 @@ class TestStorageEnv(HelperTests, unittest.TestCase):
         # obs, reward, done, info = self.env.step(act)
         # assert info["exception"]  # action should be illegal
         # assert not done  # this is fine, as it's illegal it's replaced by do nothing
-        # self._aux_test_kirchoff()
+        # self._aux_test_kirchhoff()
 
         # # trying to reconnect a storage alone on a bus => game over, not connected bus
         # array_modif = np.array([1.0, 7.0], dtype=dt_float)

--- a/grid2op/tests/test_bug_shunt_dc.py
+++ b/grid2op/tests/test_bug_shunt_dc.py
@@ -43,7 +43,7 @@ class AuxTestBugShuntDC:
             
     def test_shunt_dc(self):
         conv, exc_ = self.env.backend.runpf(is_dc=True)
-        p_subs, q_subs, p_bus, q_bus, diff_v_bus = self.env.backend.check_kirchoff()
+        p_subs, q_subs, p_bus, q_bus, diff_v_bus = self.env.backend.check_kirchhoff()
         assert np.abs(p_subs).max() <= 1e-5
         assert np.abs(p_bus).max() <= 1e-5
         # below it does not pass due to https://github.com/e2nIEE/pandapower/issues/1996 (fixed !)
@@ -54,7 +54,7 @@ class AuxTestBugShuntDC:
         conv, exc_ = self.env.backend.runpf(is_dc=True)
         assert not conv
         # does not work now because of an isolated element
-        # p_subs, q_subs, p_bus, q_bus, diff_v_bus = self.env.backend.check_kirchoff()
+        # p_subs, q_subs, p_bus, q_bus, diff_v_bus = self.env.backend.check_kirchhoff()
         # assert np.abs(p_subs).max() <= 1e-5
         # assert np.abs(p_bus).max() <= 1e-5
         # # below it does not pass due to https://github.com/e2nIEE/pandapower/issues/1996

--- a/grid2op/tests/test_forecast_env.py
+++ b/grid2op/tests/test_forecast_env.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2024, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of Grid2Op, Grid2Op a testbed platform to model sequential decision making in power systems.
+
+
+import grid2op
+import unittest
+import warnings
+
+import pdb
+
+class TestForecastEnvTester(unittest.TestCase):
+    def setUp(self) -> None:
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            # this needs to be tested with pandapower backend
+            self.env = grid2op.make("l2rpn_idf_2023", test=True, _add_to_name=type(self).__name__)
+        obs = self.env.reset(seed=0, options={"time serie id": 0})
+    
+    def tearDown(self) -> None:
+        self.env.close()
+        return super().tearDown()
+    
+    def _aux_normal_obs(self, obs, line_id=0):
+        for_env = obs.get_forecast_env()
+        for_obs = for_env.reset()
+        assert (for_obs.topo_vect == obs.topo_vect).all(), f"{(for_obs.topo_vect != obs.topo_vect).nonzero()}"
+        
+        for_obs = for_env.reset(options={"init state": {"set_line_status": [(line_id, -1)]}})
+        assert (for_obs.topo_vect != obs.topo_vect).sum() == 2
+        assert for_obs.topo_vect[type(self.env).line_or_pos_topo_vect[line_id]] == -1
+        assert for_obs.topo_vect[type(self.env).line_ex_pos_topo_vect[line_id]] == -1
+        
+        for_obs = for_env.reset(options={"init state": {"set_bus": {"lines_or_id": [(line_id, 2)]}}})
+        assert (for_obs.topo_vect != obs.topo_vect).sum() == 1
+        assert for_obs.topo_vect[type(self.env).line_or_pos_topo_vect[line_id]] == 2
+        
+    def test_normal_obs(self):
+        obs = self.env.reset(seed=0, options={"time serie id": 0})
+        self._aux_normal_obs(obs)
+        
+        obs, *_ = self.env.step(self.env.action_space())
+        self._aux_normal_obs(obs)
+
+    def test_obs_set_line_status(self):
+        obs = self.env.reset(seed=0, options={"time serie id": 0})
+        line_id = 7
+        obs, *_ = self.env.step(self.env.action_space({"set_line_status": [(line_id, -1)]}))
+        self._aux_normal_obs(obs, line_id=0)
+        
+    def test_obs_set_bus(self):
+        obs = self.env.reset(seed=0, options={"time serie id": 0})
+        line_id = 7
+        obs, *_ = self.env.step(self.env.action_space({"set_bus": {"lines_or_id": [(line_id, 2)]}}))
+        self._aux_normal_obs(obs, line_id=0)
+        
+        
+if __name__ == "__main__":
+    unittest.main()
+        

--- a/grid2op/tests/test_kirchhoff_obs.py
+++ b/grid2op/tests/test_kirchhoff_obs.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2024, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of Grid2Op, Grid2Op a testbed platform to model sequential decision making in power systems.
+
+
+import grid2op
+import unittest
+import warnings
+import numpy as np
+import pdb
+
+import grid2op.Observation
+
+class TestObsKirchhoff(unittest.TestCase):
+    def setUp(self) -> None:
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            # this needs to be tested with pandapower backend
+            self.env = grid2op.make("l2rpn_idf_2023", test=True, _add_to_name=type(self).__name__)
+        obs = self.env.reset(seed=0, options={"time serie id": 0})
+    
+    def tearDown(self) -> None:
+        self.env.close()
+        return super().tearDown()
+    
+    def _aux_normal_obs(self, obs: grid2op.Observation.BaseObservation, tol: float = 1e-4):
+        p_subs, q_subs, p_bus, q_bus, diff_v_bus = obs.check_kirchhoff()
+        assert np.abs(p_subs).max() <= tol, f"{np.abs(p_subs).max()}"
+        assert np.abs(q_subs).max() <= tol, f"{np.abs(q_subs).max()}"
+        assert np.abs(p_bus).max() <= tol, f"{np.abs(p_bus).max()}"
+        assert np.abs(q_bus).max() <= tol, f"{np.abs(q_bus).max()}"
+        assert np.abs(diff_v_bus).max() <= tol, f"{np.abs(diff_v_bus).max()}"
+        
+    def test_normal_obs(self):
+        obs = self.env.reset(seed=0, options={"time serie id": 0})
+        self._aux_normal_obs(obs)
+        
+        obs, *_ = self.env.step(self.env.action_space())
+        self._aux_normal_obs(obs)
+
+    def test_obs_set_line_status(self):
+        obs = self.env.reset(seed=0, options={"time serie id": 0})
+        line_id = 7
+        obs, *_ = self.env.step(self.env.action_space({"set_line_status": [(line_id, -1)]}))
+        self._aux_normal_obs(obs)
+        
+    def test_obs_set_bus(self):
+        obs = self.env.reset(seed=0, options={"time serie id": 0})
+        line_id = 7
+        obs, *_ = self.env.step(self.env.action_space({"set_bus": {"lines_or_id": [(line_id, 2)]}}))
+        self._aux_normal_obs(obs)
+        
+        
+if __name__ == "__main__":
+    unittest.main()
+        

--- a/grid2op/tests/test_n_busbar_per_sub.py
+++ b/grid2op/tests/test_n_busbar_per_sub.py
@@ -1306,7 +1306,7 @@ class TestPandapowerBackend_3busbars(unittest.TestCase):
                 else:
                     assert not self.env.backend._grid.line.iloc[line_ex_id]["in_service"]
     
-    def test_check_kirchoff(self):
+    def test_check_kirchhoff(self):
         cls = type(self.env)            
         res = self._aux_find_sub(self.env, cls.LOA_COL)
         if res is None:
@@ -1325,7 +1325,7 @@ class TestPandapowerBackend_3busbars(unittest.TestCase):
             self.env.backend.apply_action(bk_act)
             conv, maybe_exc = self.env.backend.runpf()
             assert conv, f"error : {maybe_exc}"
-            p_subs, q_subs, p_bus, q_bus, diff_v_bus = self.env.backend.check_kirchoff()
+            p_subs, q_subs, p_bus, q_bus, diff_v_bus = self.env.backend.check_kirchhoff()
             # assert laws are met
             assert np.abs(p_subs).max() <= 1e-5, f"error for busbar {new_bus}: {np.abs(p_subs).max():.2e}"
             assert np.abs(q_subs).max() <= 1e-5, f"error for busbar {new_bus}: {np.abs(q_subs).max():.2e}"


### PR DESCRIPTION
- [BREAKING] deprecation of `backend.check_kirchoff` in favor of `backend.check_kirchhoff` 
  (fix the typo in the name)
- [FIXED] the `obs.get_forecast_env` : in some cases the resulting first
  observation (obtained from `for_env.reset()`) did not have the correct
  topology.
- [ADDED] a method to check the KCL (`obs.check_kirchhoff`) directly from the observation
  (previously it was only possible to do it from the backend). This should 
  be used for testing purpose only
- [IMPROVED] the `backend.update_from_obs` function to work even when observation
  does not have shunt information but there are not shunts on the grid.