### PR TITLE
Fix bug in the MultifolderWithCache.seed method

### DIFF
--- a/grid2op/Chronics/multifolderWithCache.py
+++ b/grid2op/Chronics/multifolderWithCache.py
@@ -291,7 +291,7 @@ class MultifolderWithCache(Multifolder):
         """
         res = super().seed(seed)
         max_int = np.iinfo(dt_int).max
-        self._cached_seeds = np.empty(len(shape=self._cached_data), dtype=dt_int)
+        self._cached_seeds = np.empty(len(self._cached_data), dtype=dt_int)
         for i in self._order:
             data = self._cached_data[i]
             seed_ts = self.space_prng.randint(max_int)

--- a/grid2op/Chronics/multifolderWithCache.py
+++ b/grid2op/Chronics/multifolderWithCache.py
@@ -291,7 +291,7 @@ class MultifolderWithCache(Multifolder):
         """
         res = super().seed(seed)
         max_int = np.iinfo(dt_int).max
-        self._cached_seeds = np.empty(shape=self._order.shape, dtype=dt_int)
+        self._cached_seeds = np.empty(len(shape=self._cached_data), dtype=dt_int)
         for i in self._order:
             data = self._cached_data[i]
             seed_ts = self.space_prng.randint(max_int)

--- a/grid2op/tests/test_MultifolderWithCache_seed.py
+++ b/grid2op/tests/test_MultifolderWithCache_seed.py
@@ -13,10 +13,6 @@ from grid2op.Chronics import MultifolderWithCache
 import unittest
 import warnings
 
-module_name = MultifolderWithCache.__module__
-module = __import__(module_name)
-file_path = module.__file__
-print(f"Library path: \n{file_path}")
 
 class TestMultifolderWithCacheSeed(unittest.TestCase):
     def test_box_action_space(self):

--- a/grid2op/tests/test_MultifolderWithCache_seed.py
+++ b/grid2op/tests/test_MultifolderWithCache_seed.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2023, RTE (https://www.rte-france.com)
+# See AUTHORS.txt
+# This Source Code Form is subject to the terms of the Mozilla Public License, version 2.0.
+# If a copy of the Mozilla Public License, version 2.0 was not distributed with this file,
+# you can obtain one at http://mozilla.org/MPL/2.0/.
+# SPDX-License-Identifier: MPL-2.0
+# This file is part of Grid2Op, Grid2Op a testbed platform to model sequential decision making in power systems.
+
+# %%
+import os
+import grid2op
+from grid2op.Chronics import MultifolderWithCache
+import unittest
+import warnings
+
+module_name = MultifolderWithCache.__module__
+module = __import__(module_name)
+file_path = module.__file__
+print(f"Library path: \n{file_path}")
+
+class TestMultifolderWithCacheSeed(unittest.TestCase):
+    def test_box_action_space(self):
+        
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+            env = grid2op.make("l2rpn_case14_sandbox", test=True, _add_to_name=type(self).__name__,
+                               chronics_class=MultifolderWithCache)
+        
+        # I take the last chronics on purpose so that its index is larger than the number of selected chronics (only one here)
+        env.chronics_handler.real_data.set_filter(lambda x: os.path.basename(x) == "0002")
+        env.chronics_handler.reset()
+
+        try:
+            env.reset(seed=0)
+        except Exception as e:
+            self.fail(f"{type(self).__name__} raised an exception: {e}")
+
+        
+        
+# %%        
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
If you use `MultifolderWithCache` to handle chronics and if you filter chronics to keep chronics with high indexes (indexes higher than the number of selected chronics), then you obtain an "index out of bounds" bug.
This PR adresses this bug by modifying the shape on the concerned array and adding a test.