### PR TITLE
Bd dev

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -112,6 +112,15 @@ Native multi agents support:
 - [BREAKING] the way actions is serialized has been changed with respect to the `from_vect` /
   `to_vect` method. This might introduce some issues when loading previously saved actions
   with this methods.
+- [BREAKING] first kwargs of `backend.apply_action` method is now spelled `backend_action` 
+  (instead of backendAction)
+- [BREAKING] (not yet) rationalization of the backend public / private API part. The 
+  environment (and simulator, forecast env etc.) will always call the method `_public` 
+  for example `load_grid_public`, `reset_public`, `copy_public` and `apply_action_public`. 
+  These function of the base `Backend` should NOT be overriden, and will internally call 
+  the functions `load_grid`, `reset`, `copy` and `apply_action` which were part of the public
+  API. These last member functions will be renamed (in a later version) `_load_grid`,
+  `_reset`, `_copy` and `_apply_action` to reflect this change. NOT for this version however !
 - [FIXED] issue https://github.com/Grid2op/grid2op/issues/657
 - [FIXED] missing an import on the `MaskedEnvironment` class
 - [FIXED] a bug when trying to set the load_p, load_q, gen_p, gen_v by names.
@@ -143,6 +152,7 @@ Native multi agents support:
 - [FIXED] a powerflow is run when the environment is first created even before the initial "env.step"
   function is called. This is to ensure proper behaviour if env is used without being reset.
 - [FIXED] no error was catched if the backend could not properly apply the action sent by the environment.
+- [FIXED] an issue in the AAA tests: when backend does not support storages, some tests were skipped not correctly
 - [ADDED] possibility to set the "thermal limits" when calling `env.reset(..., options={"thermal limit": xxx})`
 - [ADDED] possibility to retrieve some structural information about elements with
   with `gridobj.get_line_info(...)`, `gridobj.get_load_info(...)`, `gridobj.get_gen_info(...)` 
@@ -187,7 +197,8 @@ Native multi agents support:
   that allows not to recompute it over and over again (this is internal API please do not change 
   it... unless you know what you are doing)
 - [IMPROVED] `ForecastEnv` is now part of the public API.
-    
+- [IMPROVED] no need to call `self._compute_pos_big_top()` at the end of the implementation of `backend.load_grid()`
+
 [1.10.5] - 2025-03-07
 ------------------------
 - [FIXED] force pandapower < 3 otherwise pandapower backend does not work and 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ General grid2op improvments:
 - Code and test the "load from disk" method
 - add a "plot action" method
 - does not read every data of the backend if not used
+- backend converter: now test it properly with pandapower / lightsim2grid and pypowsybl2grid
 
 Better multi processing support: 
 
@@ -96,6 +97,8 @@ Native multi agents support:
 
 - cf ad-hoc branch (dev-multiagents)
 - properly model interconnecting powerlines
+- add detachment
+- add change_bus / set_bus
 
 [1.11.0] - 202x-yy-zz
 -----------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = 'Grid2Op a Series of LF Projects, LLC,\nFor website terms of use, tr
 author = 'Benjamin Donnot'
 
 # The full version, including alpha/beta/rc tags
-release = '1.11.0.dev4'
+release = '1.11.0.dev5'
 version = '1.11'
 
 

--- a/grid2op/Action/actionSpace.py
+++ b/grid2op/Action/actionSpace.py
@@ -21,7 +21,7 @@ class ActionSpace(SerializableActionSpace):
     :class:`ActionSpace` should be created by an :class:`grid2op.Environment.Environment`
     with its parameters coming from a properly
     set up :class:`grid2op.Backend.Backend` (ie a Backend instance with a loaded powergrid.
-    See :func:`grid2op.Backend.Backend.load_grid` for
+    See :func:`grid2op.Backend.Backend.load_grid_public` for
     more information).
 
     It will allow, thanks to its :func:`ActionSpace.__call__` method to create valid :class:`BaseAction`. It is the

--- a/grid2op/Backend/backend.py
+++ b/grid2op/Backend/backend.py
@@ -766,7 +766,7 @@ class Backend(GridObjects, ABC):
         p_or, q_or, v_or, a_or = self.lines_or_info()
         return a_or
 
-    def set_thermal_limit(self, limits : Union[np.ndarray, Dict["str", float]]) -> None:
+    def set_thermal_limit(self, limits : Union[np.ndarray, Dict[str, float]]) -> None:
         """
         INTERNAL
 
@@ -794,6 +794,8 @@ class Backend(GridObjects, ABC):
               - as key the powerline names (not all names are mandatory, in that case only the powerlines with the name
                 in this dictionnary will be modified)
               - as value the new thermal limit (should be a strictly positive float).
+            
+            In all cases, limits are expected to be given in A (not in kA)
 
         """
         if isinstance(limits, np.ndarray):
@@ -891,7 +893,7 @@ class Backend(GridObjects, ABC):
         For assumption about the order of the powerline flows return in this vector, see the help of the
         :func:`Backend.get_line_status` method.
 
-        :return: An array giving the thermal limit of the powerlines.
+        :return: An array giving the thermal limit of the powerlines (in A).
         :rtype: np.array, dtype:float
         """
         return self.thermal_limit_a
@@ -972,11 +974,11 @@ class Backend(GridObjects, ABC):
         Returns
         -------
         shunt_p: ``numpy.ndarray``
-            For each shunt, the active power it withdraw at the bus to which it is connected.
+            For each shunt, the active power it withdraw at the bus to which it is connected (in MW)
         shunt_q: ``numpy.ndarray``
-            For each shunt, the reactive power it withdraw at the bus to which it is connected.
+            For each shunt, the reactive power it withdraw at the bus to which it is connected (in MVAr)
         shunt_v: ``numpy.ndarray``
-            For each shunt, the voltage magnitude of the bus to which it is connected.
+            For each shunt, the voltage magnitude of the bus to which it is connected (in kV)
         shunt_bus: ``numpy.ndarray``
             For each shunt, the bus id to which it is connected.
         """
@@ -995,15 +997,20 @@ class Backend(GridObjects, ABC):
         Returns
         -------
         line_or_theta: ``numpy.ndarray``
-            For each origin side of powerline, gives the voltage angle
+            For each origin side of powerline, gives the voltage angle (in deg) of the bus to
+            which each "origin" side is connected
         line_ex_theta: ``numpy.ndarray``
-            For each extremity side of powerline, gives the voltage angle
+            For each extremity side of powerline, gives the voltage angle (in deg) of the bus to
+            which each "ext" side is connected
         load_theta: ``numpy.ndarray``
-            Gives the voltage angle to the bus at which each load is connected
+            Gives the voltage angle to the bus at which each load is connected (in deg) of the bus to
+            which each load is connected
         gen_theta: ``numpy.ndarray``
-            Gives the voltage angle to the bus at which each generator is connected
+            Gives the voltage angle to the bus at which each generator is connected (in deg) of the bus to
+            which each generator is connected
         storage_theta: ``numpy.ndarray``
-            Gives the voltage angle to the bus at which each storage unit is connected
+            Gives the voltage angle to the bus at which each storage unit is connected  (in deg) of the bus to
+            which each storage unit is connected
         """
         raise NotImplementedError(
             "Your backend does not support the retrieval of the voltage angle theta."
@@ -1289,7 +1296,7 @@ class Backend(GridObjects, ABC):
             sum of injected reactive power at each buses. It is given in form of a matrix, with number of substations as
             row, and number of columns equal to the maximum number of buses for a substation (MVAr)
         diff_v_bus: ``numpy.ndarray`` (2d array)
-            difference between maximum voltage and minimum voltage (computed for each elements)
+            difference between maximum voltage and minimum voltage (in kV) (computed for each elements)
             at each bus. It is an array of two dimension:
 
             - first dimension represents the the substation (between 1 and self.n_sub)
@@ -1888,7 +1895,7 @@ class Backend(GridObjects, ABC):
         if type(self)._complete_action_class is None:
             # some bug in multiprocessing, this was not set
             # sub processes
-            from grid2op.Action.completeAction import CompleteAction
+            from grid2op.Action import CompleteAction
             type(self)._complete_action_class = CompleteAction.init_grid(type(self))
         set_me = self._complete_action_class()
         dict_ = {

--- a/grid2op/Backend/backend.py
+++ b/grid2op/Backend/backend.py
@@ -475,7 +475,6 @@ class Backend(GridObjects, ABC):
         self._storage_bus_target[stos_bus.changed] = stos_bus.values[stos_bus.changed]
         self._storage_bus_target.flags.writeable = False
         # TODO shunts
-        
         return self.apply_action(backend_action)
         
     def update_bus_target_after_pf(self, loads_bus, gens_bus, stos_bus):

--- a/grid2op/Backend/backend.py
+++ b/grid2op/Backend/backend.py
@@ -1266,7 +1266,7 @@ class Backend(GridObjects, ABC):
         action.update({"set_line_status": [(id_, -1)]})
         bk_act = my_cls.my_bk_act_class()
         bk_act += action
-        self.apply_action(bk_act)
+        self.apply_action_public(bk_act)
 
     def _runpf_with_diverging_exception(self, is_dc : bool) -> Optional[Exception]:
         """
@@ -2213,7 +2213,7 @@ class Backend(GridObjects, ABC):
             warnings.warn("Backend supports shunt but not the observation. This behaviour is non standard.")
         act.update(dict_)
         backend_action += act
-        self.apply_action(backend_action)
+        self.apply_action_public(backend_action)
         backend_action.reset()  # already processed by the backend
         return backend_action
 

--- a/grid2op/Backend/backend.py
+++ b/grid2op/Backend/backend.py
@@ -188,6 +188,15 @@ class Backend(GridObjects, ABC):
         #: .. versionadded: 1.11.0
         self._missing_detachment_support_info : bool = True
         self.detachment_is_allowed : bool = DEFAULT_ALLOW_DETACHMENT
+        
+        #: .. versionadded: 1.11.0
+        self._load_bus_target = None
+        self._gen_bus_target = None
+        self._storage_bus_target = None
+        
+        #: .. versionadded: 1.11.0
+        # will be used later on in future grid2op version
+        self._prevent_automatic_disconnection = True
     
     def can_handle_more_than_2_busbar(self):
         """
@@ -353,6 +362,47 @@ class Backend(GridObjects, ABC):
         else:
             raise BackendError('Impossible to unset the "is_loaded" status.')
 
+    def load_grid_public(self,
+                         path : Union[os.PathLike, str],
+                         filename : Optional[Union[os.PathLike, str]]=None
+                         ) -> None:
+        """
+        INTERNAL
+
+        .. warning:: /!\\\\ Internal, do not use unless you know what you are doing /!\\\\
+
+            This is called once at the loading of the powergrid.
+
+        .. note::
+            As of grid2op 1.11.0 this function is replacing the function :func:`Backend.load_grid` 
+            for the "public backend API".
+            
+            Avoid calling directly the :func:`Backend.load_grid` directly and use this 
+            one instead.
+        
+        """
+        # first load the grid for the public part
+        self.load_grid(path, filename)
+        
+        # and finish the initialization with a call to this function
+        self._compute_pos_big_topo()
+        
+        self._load_bus_target = np.empty(self.n_load, dtype=dt_int)
+        self._gen_bus_target =  np.empty(self.n_gen, dtype=dt_int)
+        self._storage_bus_target = np.empty(self.n_storage, dtype=dt_int)
+        
+        if self._missing_detachment_support_info:
+            self.detachment_is_allowed = DEFAULT_ALLOW_DETACHMENT
+            type(self).detachment_is_allowed = DEFAULT_ALLOW_DETACHMENT
+            warnings.warn("Your backend implementation has called neither `self.can_handle_detachment()` "
+                          "nor `self.cannot_handle_detachment()`. The detachment feature wille not be available")
+        if self._missing_two_busbars_support_info:
+            self.n_busbar_per_sub = DEFAULT_N_BUSBAR_PER_SUB
+            type(self).n_busbar_per_sub = DEFAULT_N_BUSBAR_PER_SUB
+            warnings.warn("Your backend implementation has called neither `self.can_handle_more_than_2_busbar()` "
+                          f"nor `self.cannot_handle_more_than_2_busbar()`. Setting at most {DEFAULT_N_BUSBAR_PER_SUB} "
+                          "(default) independant busbars per substation.")
+        
     @abstractmethod
     def load_grid(self,
                   path : Union[os.PathLike, str],
@@ -365,6 +415,7 @@ class Backend(GridObjects, ABC):
             This is called once at the loading of the powergrid.
 
         Load the powergrid.
+        
         It should first define self._grid.
 
         And then fill all the helpers used by the backend eg. all the attributes of :class:`Space.GridObjects`.
@@ -383,8 +434,63 @@ class Backend(GridObjects, ABC):
         """
         pass
 
+    def apply_action_public(self, backend_action: Union["grid2op.Action._backendAction._BackendAction", None]) -> None:
+        """
+        INTERNAL
+
+        .. warning:: /!\\\\ Internal, do not use unless you know what you are doing /!\\\\
+
+        .. note::
+            As of grid2op 1.11.0 this function is replacing the function :func:`Backend.apply_action` 
+            for the "public backend API".
+            
+            Avoid calling directly the :func:`Backend.apply_action` directly and use this 
+            one instead.
+        
+        """
+        if backend_action is None:
+            return
+        
+        # "compile" the grid2op backend action
+        (
+            active_bus,
+            (prod_p, prod_v, load_p, load_q, storage),
+            topo__,
+            shunts__,
+        ) = backend_action()
+        
+        # store the states
+        loads_bus = backend_action.get_loads_bus()
+        self._load_bus_target.flags.writeable = True
+        self._load_bus_target[loads_bus.changed] = loads_bus.values
+        self._load_bus_target.flags.writeable = False
+        
+        gens_bus = backend_action.get_gens_bus()
+        self._gen_bus_target.flags.writeable = True
+        self._gen_bus_target[gens_bus.changed] = gens_bus.values
+        self._gen_bus_target.flags.writeable = False
+        
+        stos_bus = backend_action.get_storages_bus()
+        self._storage_bus_target.flags.writeable = True
+        self._storage_bus_target[stos_bus.changed] = stos_bus.values
+        self._storage_bus_target.flags.writeable = False
+        # TODO shunts
+        
+        return self.apply_action(backend_action)
+        
+    def update_bus_target_after_pf(self, loads_bus, gens_bus, stos_bus):
+        self._load_bus_target.flags.writeable = True
+        self._load_bus_target[:] = loads_bus
+        self._load_bus_target.flags.writeable = False
+        self._gen_bus_target.flags.writeable = True
+        self._gen_bus_target[:] = gens_bus
+        self._gen_bus_target.flags.writeable = False
+        self._storage_bus_target.flags.writeable = True
+        self._storage_bus_target[:] = stos_bus
+        self._storage_bus_target.flags.writeable = False
+        
     @abstractmethod
-    def apply_action(self, backendAction: Union["grid2op.Action._backendAction._BackendAction", None]) -> None:
+    def apply_action(self, backend_action: "grid2op.Action._backendAction._BackendAction") -> None:
         """
         INTERNAL
 
@@ -395,12 +501,16 @@ class Backend(GridObjects, ABC):
 
             This is one of the core function if you want to code a backend.
 
-        Modify the powergrid with the action given by an agent or by the envir.
+        .. warning::
+            As of grid2op 1.11.0 this function is not part of the public API and is not called directly
+            by the environment. This is called by the function :func:`Backend.apply_action_public`.
+            
+            From this grid2Op version onward, the input parameters `backend_action` is always not None.
+            Before that, it could be None.
+
+        Modify the powergrid with the action given by an agent or by the environment.
         For the L2RPN project, this action is mainly for topology if it has been sent by the agent.
         Or it can also affect production and loads, if the action is made by the environment.
-
-        The help of :func:`grid2op.BaseAction.BaseAction.__call__` or the code in BaseActiontion.py file give more information about
-        the implementation of this method.
 
         :param backendAction: the action to be implemented on the powergrid.
         :type action: :class:`grid2op.Action._BackendAction._BackendAction`
@@ -623,6 +733,30 @@ class Backend(GridObjects, ABC):
         """
         pass
 
+    def reset_public(self,
+                     path : Union[os.PathLike, str],
+                     grid_filename : Optional[Union[os.PathLike, str]]=None) -> None:
+        """
+        INTERNAL
+
+        .. warning:: /!\\\\ Internal, do not use unless you know what you are doing /!\\\\
+
+            This is done in the `env.reset()` method and should be performed otherwise.
+            
+        .. note::
+            As of grid2op 1.11.0 this function is replacing the function :func:`Backend.reset` 
+            for the "public backend API".
+            
+            Avoid calling directly the :func:`Backend.reset` directly and use this 
+            one instead.
+        """
+        # reset the self._grid and others
+        self.reset(path, grid_filename)
+        
+        # reset the other attributes
+        self.comp_time = 0.0
+        self.update_bus_target_after_pf(-1, -1, -1)
+        
     def reset(self,
               path : Union[os.PathLike, str],
               grid_filename : Optional[Union[os.PathLike, str]]=None) -> None:
@@ -633,13 +767,75 @@ class Backend(GridObjects, ABC):
 
             This is done in the `env.reset()` method and should be performed otherwise.
 
+        .. warning::
+            As of grid2op 1.11.0 this function is not part of the public API and is not called directly
+            by the environment. This is called by the function :func:`Backend.reset_public`
+
         Reload the power grid.
         For backwards compatibility this method calls `Backend.load_grid`.
         But it is encouraged to overload it in the subclasses.
         """
-        self.comp_time = 0.0
         self.load_grid(path, filename=grid_filename)
 
+    def copy_public(self) -> Self:
+        """
+        INTERNAL
+
+        .. warning:: /!\\\\ Internal, do not use unless you know what you are doing /!\\\\
+        
+        This function returns a copy of the backend.
+            
+        .. note::
+            As of grid2op 1.11.0 this function is replacing the function :func:`Backend.copy` 
+            for the "public backend API".
+            
+            Avoid calling directly the :func:`Backend.copy` directly and use this 
+            one instead.
+            
+        """
+        
+        if not self._can_be_copied:
+            raise BaseException("This backend cannot be copied")
+        
+        # copy all the inherited attribute(s) (including self._grid)
+        res = self.copy()
+        
+        # if it's set to true, it returns all intermediate _grid states. This can slow down the computation!
+        res.detailed_infos_for_cascading_failures = self.detailed_infos_for_cascading_failures
+        res.supported_grid_format = copy.deepcopy(self.supported_grid_format)
+        
+        # the power _grid manipulated. One powergrid per backend.
+        # self._grid : Any = None  # should be handled in self.copy() 
+
+        # thermal limit setting, in ampere, at the same "side" of the powerline than self.get_line_overflow
+        res.thermal_limit_a = copy.deepcopy(self.thermal_limit_a)
+
+        # for the shunt (only if supported)
+        res._sh_vnkv = copy.deepcopy(self._sh_vnkv)
+
+        res.comp_time = copy.deepcopy(self.comp_time)
+        res.can_output_theta = copy.deepcopy(self.comp_time)
+
+        # to prevent the use of the same backend instance in different environment.
+        res._is_loaded = copy.deepcopy(self.comp_time)
+
+        res._can_be_copied = copy.deepcopy(self._can_be_copied)
+        
+        res._my_kwargs = {"detailed_infos_for_cascading_failures": self.detailed_infos_for_cascading_failures,
+                          "can_be_copied": self._can_be_copied}
+        for k, v in self._my_kwargs.items():
+            res._my_kwargs[k] = v
+            
+        res._missing_two_busbars_support_info = copy.deepcopy(self._missing_two_busbars_support_info)
+        res.n_busbar_per_sub = copy.deepcopy(self.n_busbar_per_sub)
+        res._missing_detachment_support_info = copy.deepcopy(self._missing_detachment_support_info)
+        res.detachment_is_allowed = copy.deepcopy(self.detachment_is_allowed)
+        res._load_bus_target = copy.deepcopy(self._load_bus_target)
+        res._gen_bus_target = copy.deepcopy(self._gen_bus_target)
+        res._storage_bus_target = copy.deepcopy(self._storage_bus_target)
+        res._prevent_automatic_disconnection = copy.deepcopy(self._prevent_automatic_disconnection)
+        return res
+    
     def copy(self) -> Self:
         """
         INTERNAL
@@ -658,7 +854,11 @@ class Backend(GridObjects, ABC):
             example) :func:`grid2op.Observation.BaseObservation.simulate` nor
             the :class:`grid2op.simulator.Simulator` for example.
 
-        Performs a deep copy of the backend.
+        .. warning::
+            As of grid2op 1.11.0 this function is not part of the public API and is not called directly
+            by the environment. This is called by the function :func:`Backend.copy_public`
+            
+        Performs a deep copy of the "attributed" of the inherited class, including the `self._grid`
 
         In the default implementation we explicitly called the deepcopy operator on `self._grid` to make the
         error message more explicit in case there is a problem with this part.
@@ -1119,7 +1319,21 @@ class Backend(GridObjects, ABC):
                     raise BackendError((cls.ERR_DETACHMENT.format("storages", "storages", sto_maybe_error.nonzero()[0]) + 
                                         " NB storage units are allowed to be disconnected even if "
                                         "`detachment_is_allowed` is False but only if the don't produce active power."))
-                
+            
+            # additional check: if the backend detach some things incorrectly
+            if cls.detachment_is_allowed:
+                # if the backend automatically disconnect things, I need to catch them
+                # with grid2op 1.11.0 it is not feasible
+                if self._prevent_automatic_disconnection and ((self._load_bus_target != -1) & (load_buses == -1)).any():
+                    issue = (self._load_bus_target != -1) & (load_buses == -1)
+                    raise BackendError(f"Your backend apparently disconnected load(s) id {issue.nonzero()[0]}, "
+                                       f"named {type(self).name_load[issue.nonzero()[0]]}")
+                if self._prevent_automatic_disconnection and ((self._gen_bus_target != -1) & (gen_buses == -1)).any():
+                    issue = (self._gen_bus_target != -1) & (gen_buses == -1)
+                    raise BackendError(f"Your backend apparently disconnected gens(s) id {issue.nonzero()[0]}, "
+                                       f"named {type(self).name_gen[issue.nonzero()[0]]}")
+                # TODO storage units
+                    
         except Grid2OpException as exc_:
             exc_me = exc_
             

--- a/grid2op/Backend/backend.py
+++ b/grid2op/Backend/backend.py
@@ -462,17 +462,17 @@ class Backend(GridObjects, ABC):
         # store the states
         loads_bus = backend_action.get_loads_bus()
         self._load_bus_target.flags.writeable = True
-        self._load_bus_target[loads_bus.changed] = loads_bus.values
+        self._load_bus_target[loads_bus.changed] = loads_bus.values[loads_bus.changed]
         self._load_bus_target.flags.writeable = False
         
         gens_bus = backend_action.get_gens_bus()
         self._gen_bus_target.flags.writeable = True
-        self._gen_bus_target[gens_bus.changed] = gens_bus.values
+        self._gen_bus_target[gens_bus.changed] = gens_bus.values[gens_bus.changed]
         self._gen_bus_target.flags.writeable = False
         
         stos_bus = backend_action.get_storages_bus()
         self._storage_bus_target.flags.writeable = True
-        self._storage_bus_target[stos_bus.changed] = stos_bus.values
+        self._storage_bus_target[stos_bus.changed] = stos_bus.values[stos_bus.changed]
         self._storage_bus_target.flags.writeable = False
         # TODO shunts
         

--- a/grid2op/Backend/backend.py
+++ b/grid2op/Backend/backend.py
@@ -488,6 +488,21 @@ class Backend(GridObjects, ABC):
         self._storage_bus_target[:] = stos_bus
         self._storage_bus_target.flags.writeable = False
         
+    def handle_grid2op_compat(self):
+        """This function will resize the _load_bus_target, _gen_bus_target and _storage_bus_target
+        to match the new size after compatibility mode.
+        """
+        cls = type(self)
+        self._load_bus_target.flags.writeable = True
+        self._load_bus_target.resize(cls.n_load)
+        self._load_bus_target.flags.writeable = False
+        self._gen_bus_target.flags.writeable = True
+        self._gen_bus_target.resize(cls.n_gen)
+        self._gen_bus_target.flags.writeable = False
+        self._storage_bus_target.flags.writeable = True
+        self._storage_bus_target.resize(cls.n_storage)
+        self._storage_bus_target.flags.writeable = False
+        
     @abstractmethod
     def apply_action(self, backend_action: "grid2op.Action._backendAction._BackendAction") -> None:
         """

--- a/grid2op/Backend/educPandaPowerBackend.py
+++ b/grid2op/Backend/educPandaPowerBackend.py
@@ -218,22 +218,19 @@ class EducPandaPowerBackend(Backend):
         # type(self).set_no_storage()
 
     ###### modify the grid
-    def apply_action(self, backendAction: Union["grid2op.Action._backendAction._BackendAction", None]) -> None:
+    def apply_action(self, backend_action: "grid2op.Action._backendAction._BackendAction") -> None:
         """
         Here the implementation of the "modify the grid" function.
 
         From the documentation, it's pretty straightforward, even though the implementation takes ~70 lines of code.
         Most of them being direct copy paste from the examples in the documentation.
         """
-        if backendAction is None:
-            return
-
         (
             active_bus,
             (prod_p, prod_v, load_p, load_q, storage),
             _,
             shunts__,
-        ) = backendAction()
+        ) = backend_action()
 
         for gen_id, new_p in prod_p:
             self._grid.gen["p_mw"].iloc[gen_id] = new_p
@@ -249,7 +246,7 @@ class EducPandaPowerBackend(Backend):
             self._grid.load["q_mvar"].iloc[load_id] = new_q
 
         # now i deal with the topology
-        loads_bus = backendAction.get_loads_bus()
+        loads_bus = backend_action.get_loads_bus()
         for load_id, new_bus in loads_bus:
             if new_bus == -1:
                 self._grid.load["in_service"][load_id] = False
@@ -262,7 +259,7 @@ class EducPandaPowerBackend(Backend):
                     self.load_to_subid[load_id] + (new_bus - 1) * self.n_sub
                 )
 
-        gens_bus = backendAction.get_gens_bus()
+        gens_bus = backend_action.get_gens_bus()
         for gen_id, new_bus in gens_bus:
             if new_bus == -1:
                 self._grid.gen["in_service"][gen_id] = False
@@ -272,7 +269,7 @@ class EducPandaPowerBackend(Backend):
                     self.gen_to_subid[gen_id] + (new_bus - 1) * self.n_sub
                 )
 
-        lines_or_bus = backendAction.get_lines_or_bus()
+        lines_or_bus = backend_action.get_lines_or_bus()
         for line_id, new_bus in lines_or_bus:
             if line_id < self._nb_real_line_pandapower:
                 dt = self._grid.line
@@ -291,7 +288,7 @@ class EducPandaPowerBackend(Backend):
                     self.line_or_to_subid[line_id] + (new_bus - 1) * self.n_sub
                 )
 
-        lines_ex_bus = backendAction.get_lines_ex_bus()
+        lines_ex_bus = backend_action.get_lines_ex_bus()
         for line_id, new_bus in lines_ex_bus:
             if line_id < self._nb_real_line_pandapower:
                 dt = self._grid.line

--- a/grid2op/Backend/pandaPowerBackend.py
+++ b/grid2op/Backend/pandaPowerBackend.py
@@ -254,7 +254,7 @@ class PandaPowerBackend(Backend):
                     warnings.warn(
                         f'There are "{el_nm}" in the pandapower grid. These '
                         f"elements are not modeled on grid2op side (the environment will "
-                        f"work, but you won't be able to modify them)."
+                        f"work, but you won't be able to modify them with 'pure grid2op' API)."
                     )
 
     def get_theta(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
@@ -859,7 +859,7 @@ class PandaPowerBackend(Backend):
         """
         return self._big_topo_to_obj[id_big_topo]
 
-    def apply_action(self, backendAction: Union["grid2op.Action._backendAction._BackendAction", None]) -> None:
+    def apply_action(self, backend_action: "grid2op.Action._backendAction._BackendAction") -> None:
         """
         INTERNAL
 
@@ -867,8 +867,6 @@ class PandaPowerBackend(Backend):
 
         Specific implementation of the method to apply an action modifying a powergrid in the pandapower format.
         """
-        if backendAction is None:
-            return
         cls = type(self)
         
         (
@@ -876,7 +874,7 @@ class PandaPowerBackend(Backend):
             (prod_p, prod_v, load_p, load_q, storage),
             topo__,
             shunts__,
-        ) = backendAction()
+        ) = backend_action()
         
         # handle bus status
         self._grid.bus["in_service"] = pd.Series(data=active_bus.T.reshape(-1),
@@ -913,7 +911,7 @@ class PandaPowerBackend(Backend):
             if (storage.changed).any():
                 tmp_stor_p.iloc[storage.changed] = storage.values[storage.changed]
             # topology of the storage
-            stor_bus = backendAction.get_storages_bus()
+            stor_bus = backend_action.get_storages_bus()
             new_bus_num = dt_int(1) * self._grid.storage["bus"].values
             new_bus_id = stor_bus.values[stor_bus.changed]
             new_bus_num[stor_bus.changed] = cls.local_bus_to_global(new_bus_id, cls.storage_to_subid[stor_bus.changed])
@@ -924,7 +922,7 @@ class PandaPowerBackend(Backend):
             self._grid.storage.loc[stor_bus.changed & ~deactivated, "in_service"] = True
             self._grid.storage["bus"] = new_bus_num
         
-        if type(backendAction).shunts_data_available:
+        if type(backend_action).shunts_data_available:
             shunt_p, shunt_q, shunt_bus = shunts__
 
             if (shunt_p.changed).any():

--- a/grid2op/Converter/BackendConverter.py
+++ b/grid2op/Converter/BackendConverter.py
@@ -181,6 +181,33 @@ class BackendConverter(Backend):
             # both source and target backend understands the same format
             self.target_backend.load_grid(path, filename)
         
+        self.source_backend._compute_pos_big_topo()
+        self.target_backend._compute_pos_big_topo()
+        
+        # and now initialize the attributes (see list bellow)
+        li_attrs = ["n_line", "n_gen", "n_load", "n_sub",
+                    "load_to_subid", "gen_to_subid", "line_or_to_subid",
+                    "line_ex_to_subid", "name_load", "name_gen",
+                    "name_line", "name_sub",
+                    "sub_info", "dim_topo",
+                    "load_to_sub_pos",
+                    "gen_to_sub_pos",
+                    "line_or_to_sub_pos",
+                    "line_ex_to_sub_pos",
+                    "load_pos_topo_vect",
+                    "gen_pos_topo_vect",
+                    "line_or_pos_topo_vect",
+                    "line_ex_pos_topo_vect",
+                    # storage
+                    "name_storage",
+                    "n_storage",
+                    "storage_to_subid",
+                    "storage_to_sub_pos",
+                    "storage_pos_topo_vect"
+                    ]
+        for attr_nm in li_attrs:
+            setattr(self, attr_nm, getattr(self.source_backend, attr_nm))
+        
         # TODO in case source supports the "more than 2" feature but not target
         # it's unclear how I can "reload" the grid...
         # if (not self.target_backend._missing_two_busbars_support_info and
@@ -234,13 +261,13 @@ class BackendConverter(Backend):
                 == sorted(self.target_backend.name_sub)
             ):
                 for id_source, nm_source in enumerate(self.source_backend.name_sub):
-                    id_target = (self.target_backend.name_sub == nm_source).nonzero()[0]
+                    id_target = (self.target_backend.name_sub == nm_source).nonzero()[0][0]
                     self._sub_tg2sr[id_source] = id_target
                     self._sub_sr2tg[id_target] = id_source
         else:
             for id_source, nm_source in enumerate(self.source_backend.name_sub):
                 nm_target = self.sub_source_target[nm_source]
-                id_target = (self.target_backend.name_sub == nm_target).nonzero()[0]
+                id_target = (self.target_backend.name_sub == nm_target).nonzero()[0][0]
                 self._sub_tg2sr[id_source] = id_target
                 self._sub_sr2tg[id_target] = id_source
 
@@ -596,9 +623,12 @@ class BackendConverter(Backend):
         self.source_backend.close()
         self.target_backend.close()
 
-    def apply_action(self, action):
+    def apply_action_public(self, backend_action):
+        return super().apply_action_public(backend_action)
+    
+    def apply_action(self, backend_action):
         # action is from the source backend
-        action_target = self._transform_action(action)
+        action_target = self._transform_action(backend_action)
         self.target_backend.apply_action(action_target)
 
     def runpf(self, is_dc=False):

--- a/grid2op/Environment/baseEnv.py
+++ b/grid2op/Environment/baseEnv.py
@@ -747,7 +747,7 @@ class BaseEnv(GridObjects, RandomObject, ABC):
         new_obj._backend_action = copy.deepcopy(self._backend_action)
 
         # specific to Basic Env, do not change
-        new_obj.backend = self.backend.copy()
+        new_obj.backend = self.backend.copy_public()
         if self._thermal_limit_a is not None:
             new_obj.backend.set_thermal_limit(self._thermal_limit_a)
         new_obj._thermal_limit_a = copy.deepcopy(self._thermal_limit_a)

--- a/grid2op/Environment/baseEnv.py
+++ b/grid2op/Environment/baseEnv.py
@@ -3635,7 +3635,7 @@ class BaseEnv(GridObjects, RandomObject, ABC):
                 self._time_opponent += tock - tick
                 self._time_create_bk_act += tock - beg_
                 try:
-                    self.backend.apply_action(self._backend_action)
+                    self.backend.apply_action_public(self._backend_action)
                 except ImpossibleTopology as exc_:
                     has_error = True
                     except_.append(exc_)

--- a/grid2op/Environment/baseEnv.py
+++ b/grid2op/Environment/baseEnv.py
@@ -3233,7 +3233,6 @@ class BaseEnv(GridObjects, RandomObject, ABC):
         # save the current topology as "last" topology (for connected powerlines)
         # and update the state of the disconnected powerline due to cascading failure
         self._backend_action.update_state(disc_lines)
-
         # one timestep passed, i can maybe reconnect some lines
         self._times_before_line_status_actionable[
             self._times_before_line_status_actionable > 0
@@ -3303,13 +3302,16 @@ class BaseEnv(GridObjects, RandomObject, ABC):
         
         # set the status of the other elements (if the backend 
         # disconnect them)
+        topo_ = self.backend.get_topo_vect()
         if cls.detachment_is_allowed:
             gen_detached_user = self._backend_action.get_gen_detached()
-            topo_ = self.backend.get_topo_vect()
             self._backend_action.current_topo.values[:] = topo_
             self._aux_update_detachment_info()
         else:
             gen_detached_user = np.zeros(cls.n_gen, dtype=dt_bool)
+        self.backend.update_bus_target_after_pf(topo_[cls.load_pos_topo_vect],
+                                                topo_[cls.gen_pos_topo_vect],
+                                                topo_[cls.storage_pos_topo_vect])
             
         # problem with the gen_activeprod_t above, is that the slack bus absorbs alone all the losses
         # of the system. So basically, when it's too high (higher than the ramp) it can

--- a/grid2op/Environment/environment.py
+++ b/grid2op/Environment/environment.py
@@ -298,7 +298,7 @@ class Environment(BaseEnv):
             if self._compat_glop_version is not None:
                 type(self.backend).glop_version = self._compat_glop_version
             
-            self.backend.load_grid(
+            self.backend.load_grid_public(
                 self._init_grid_path
             )  # the real powergrid of the environment
             self.backend.load_storage_data(self.get_path_env())
@@ -962,7 +962,7 @@ class Environment(BaseEnv):
         self._last_obs = None
         
         # the real powergrid of the environment
-        self.backend.reset(self._init_grid_path)  
+        self.backend.reset_public(self._init_grid_path)  
         
         # self.backend.assert_grid_correct()
         self._previous_conn_state.update_from_other(self._cst_prev_state_at_init)
@@ -1604,7 +1604,7 @@ class Environment(BaseEnv):
             if not self.backend._can_be_copied:
                 raise RuntimeError("Impossible to get the kwargs for this "
                                    "environment, the backend cannot be copied.")
-            res["backend"] = self.backend.copy()
+            res["backend"] = self.backend.copy_public()
             res["backend"]._is_loaded = False  # i can reload a copy of an environment
         
         res["parameters"] = copy.deepcopy(self._parameters)

--- a/grid2op/Environment/environment.py
+++ b/grid2op/Environment/environment.py
@@ -672,6 +672,7 @@ class Environment(BaseEnv):
             if need_process_backend:
                 # the following line must be called BEFORE "self.backend.assert_grid_correct()" !
                 self.backend.storage_deact_for_backward_comaptibility()
+                self.backend.handle_grid2op_compat()
 
     def _voltage_control(self, agent_action, prod_v_chronics):
         """

--- a/grid2op/Observation/baseObservation.py
+++ b/grid2op/Observation/baseObservation.py
@@ -4958,7 +4958,7 @@ class BaseObservation(GridObjects):
                              maintenance=maintenance)
         ch.max_iter = ch.real_data.max_iter
         
-        backend = self._obs_env.backend.copy()
+        backend = self._obs_env.backend.copy_public()
         backend._is_loaded = True
         nb_highres_called = self._obs_env.highres_sim_counter.nb_highres_called
         res = ForecastEnv(**self._ptr_kwargs_env,

--- a/grid2op/Observation/observationSpace.py
+++ b/grid2op/Observation/observationSpace.py
@@ -213,7 +213,7 @@ class ObservationSpace(SerializableObservationSpace):
         observation_bk_class_used = observation_bk_class.init_grid(type(env.backend), _local_dir_cls=_local_dir_cls)
         self._backend_obs = observation_bk_class_used(**observation_bk_kwargs)   
         self._backend_obs.set_env_name(env.name)
-        self._backend_obs.load_grid(path_grid_for)
+        self._backend_obs.load_grid_public(path_grid_for)
         self._backend_obs.assert_grid_correct()
         self._backend_obs.runpf()
         self._backend_obs.assert_grid_correct_after_powerflow()
@@ -245,7 +245,7 @@ class ObservationSpace(SerializableObservationSpace):
             # case where I can copy the backend for the 'simulate' and I don't need to build 
             # it (uses same class and same grid)
             try:
-                self._backend_obs = env.backend.copy()
+                self._backend_obs = env.backend.copy_public()
             except Exception as exc_:
                 self._backend_obs = None
                 self.logger.warn(f"Backend cannot be copied, simulate feature will "

--- a/grid2op/Reward/n1Reward.py
+++ b/grid2op/Reward/n1Reward.py
@@ -67,7 +67,7 @@ class N1Reward(BaseReward):
         self.l_id = l_id
 
     def initialize(self, env):
-        self._backend = env.backend.copy()
+        self._backend = env.backend.copy_public()
         bk_act_cls = _BackendAction.init_grid(env.backend)
         self._backend_action = bk_act_cls()
 

--- a/grid2op/Space/GridObjects.py
+++ b/grid2op/Space/GridObjects.py
@@ -137,7 +137,7 @@ class GridObjects:
         - method 4 (recommended): use the :func:`GridObjects.topo_vect_element`
 
     For a given powergrid, this object should be initialized once in the :class:`grid2op.Backend.Backend` when
-    the first call to :func:`grid2op.Backend.Backend.load_grid` is performed. In particular the following attributes
+    the first call to :func:`grid2op.Backend.Backend.load_grid_public` is performed. In particular the following attributes
     must necessarily be defined (see above for a detailed description of some of the attributes):
 
     - :attr:`GridObjects.name_load`

--- a/grid2op/__init__.py
+++ b/grid2op/__init__.py
@@ -11,7 +11,7 @@
 Grid2Op a testbed platform to model sequential decision making in power systems.
 """
 
-__version__ = '1.11.0.dev4'
+__version__ = '1.11.0.dev5'
 
 __all__ = [
     "Action",

--- a/grid2op/simulator/simulator.py
+++ b/grid2op/simulator/simulator.py
@@ -217,7 +217,7 @@ class Simulator(object):
             grid_path_loaded = os.path.join(path_env, grid_forecast_name)
         else:
             grid_path_loaded = grid_path 
-        tmp_backend.load_grid(grid_path_loaded)
+        tmp_backend.load_grid_public(grid_path_loaded)
         tmp_backend.assert_grid_correct()
         tmp_backend.runpf()
         tmp_backend.assert_grid_correct_after_powerflow()

--- a/grid2op/simulator/simulator.py
+++ b/grid2op/simulator/simulator.py
@@ -58,7 +58,7 @@ class Simulator(object):
                     'make sure you set the kwarg "env=None"'
                 )
             if backend._can_be_copied:
-                self.backend: Backend = backend.copy()
+                self.backend: Backend = backend.copy_public()
             else:
                 raise SimulatorError("Impossible to make a Simulator when you "
                                      "cannot copy the backend.")
@@ -75,7 +75,7 @@ class Simulator(object):
                     f"inheriting from BaseEnv"
                 )
             if env.backend._can_be_copied:
-                self.backend: Backend = env.backend.copy()
+                self.backend: Backend = env.backend.copy_public()
             else:
                 raise SimulatorError("Impossible to make a Simulator when you "
                                      "cannot copy the backend of the environment.")
@@ -125,7 +125,7 @@ class Simulator(object):
                 "Have you used `simulator.set_state(obs, ...)` with a valid observation before ?"
             )
         res = copy.copy(self)
-        res.backend = res.backend.copy()
+        res.backend = res.backend.copy_public()
         res.current_obs = res.current_obs.copy()
         # do not copy this !
         res._highres_sim_counter = self._highres_sim_counter
@@ -161,7 +161,7 @@ class Simulator(object):
                 " be an object (an not a class) of type backend"
             )
         self.backend.close()
-        self.backend = backend.copy()  # backend_class.init_grid(type(self.backend))
+        self.backend = backend.copy_public()  # backend_class.init_grid(type(self.backend))
         self.set_state(obs=self.current_obs)
 
     def change_backend_type(self, backend_type: type, grid_path: os.PathLike, **kwargs):

--- a/grid2op/tests/BaseBackendTest.py
+++ b/grid2op/tests/BaseBackendTest.py
@@ -103,7 +103,7 @@ class BaseTestLoadingCase(MakeBackend):
         case_file = self.get_casefile()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
-            backend.load_grid(path_matpower, case_file)
+            backend.load_grid_public(path_matpower, case_file)
         type(backend).set_env_name("BaseTestLoadingCase")
         backend.assert_grid_correct()
 
@@ -197,7 +197,7 @@ class BaseTestLoadingCase(MakeBackend):
         case_file = self.get_casefile()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
-            backend.load_grid(path_matpower, case_file)
+            backend.load_grid_public(path_matpower, case_file)
         type(backend).set_env_name("TestLoadingCase_env2_test_assert_grid_correct")
         backend.assert_grid_correct()
         conv, *_  = backend.runpf()
@@ -218,7 +218,7 @@ class BaseTestLoadingBackendFunc(MakeBackend):
         self.case_file = self.get_casefile()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
-            self.backend.load_grid(self.path_matpower, self.case_file)
+            self.backend.load_grid_public(self.path_matpower, self.case_file)
         type(self.backend).set_env_name("TestLoadingBackendFunc_env")
         type(self.backend).set_no_storage()
         self.backend.assert_grid_correct()
@@ -828,7 +828,7 @@ class BaseTestTopoAction(MakeBackend):
         self.case_file = self.get_casefile()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
-            self.backend.load_grid(self.path_matpower, self.case_file)
+            self.backend.load_grid_public(self.path_matpower, self.case_file)
         type(self.backend).set_env_name("BaseTestTopoAction")
         type(self.backend).set_no_storage()
         self.backend.assert_grid_correct()
@@ -1577,7 +1577,7 @@ class BaseTestEnvPerformsCorrectCascadingFailures(MakeBackend):
         self.case_file = self.get_casefile()
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
-            self.backend.load_grid(self.path_matpower, self.case_file)
+            self.backend.load_grid_public(self.path_matpower, self.case_file)
         type(self.backend).set_env_name("TestEnvPerformsCorrectCascadingFailures_env")
         type(self.backend).set_no_storage()
         self.backend.assert_grid_correct()
@@ -1659,7 +1659,7 @@ class BaseTestEnvPerformsCorrectCascadingFailures(MakeBackend):
             )
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
-            self.backend.load_grid(self.path_matpower, case_file)
+            self.backend.load_grid_public(self.path_matpower, case_file)
         type(self.backend).set_no_storage()
         self.backend.assert_grid_correct()
 
@@ -1694,7 +1694,7 @@ class BaseTestEnvPerformsCorrectCascadingFailures(MakeBackend):
             )
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
-            self.backend.load_grid(self.path_matpower, case_file)
+            self.backend.load_grid_public(self.path_matpower, case_file)
         type(self.backend).set_no_storage()
         self.backend.assert_grid_correct()
         conv, *_ = self.backend.runpf()
@@ -1738,7 +1738,7 @@ class BaseTestEnvPerformsCorrectCascadingFailures(MakeBackend):
             )
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
-            self.backend.load_grid(self.path_matpower, case_file)
+            self.backend.load_grid_public(self.path_matpower, case_file)
         type(self.backend).set_no_storage()
         self.backend.assert_grid_correct()
         conv, *_ = self.backend.runpf()
@@ -1783,7 +1783,7 @@ class BaseTestEnvPerformsCorrectCascadingFailures(MakeBackend):
             )
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
-            self.backend.load_grid(self.path_matpower, case_file)
+            self.backend.load_grid_public(self.path_matpower, case_file)
         type(self.backend).set_no_storage()
         self.backend.assert_grid_correct()
 
@@ -1825,7 +1825,7 @@ class BaseTestEnvPerformsCorrectCascadingFailures(MakeBackend):
             )
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
-            self.backend.load_grid(self.path_matpower, case_file)
+            self.backend.load_grid_public(self.path_matpower, case_file)
         type(self.backend).set_no_storage()
         self.backend.assert_grid_correct()
 
@@ -1868,7 +1868,7 @@ class BaseTestEnvPerformsCorrectCascadingFailures(MakeBackend):
             )
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore")
-            self.backend.load_grid(self.path_matpower, case_file)
+            self.backend.load_grid_public(self.path_matpower, case_file)
         type(self.backend).set_no_storage()
         self.backend.assert_grid_correct()
 

--- a/grid2op/tests/BaseBackendTest.py
+++ b/grid2op/tests/BaseBackendTest.py
@@ -393,7 +393,7 @@ class BaseTestLoadingBackendFunc(MakeBackend):
         l_id = 3
 
         p_or_orig, *_ = self.backend.lines_or_info()
-        backend_cpy = self.backend.copy()
+        backend_cpy = self.backend.copy_public()
 
         self.backend._disconnect_line(l_id)
         conv, *_ = self.backend.runpf(is_dc=is_dc)
@@ -419,7 +419,7 @@ class BaseTestLoadingBackendFunc(MakeBackend):
         conv, *_  = self.backend.runpf(is_dc=False)
         p_or_orig, *_ = self.backend.lines_or_info()
 
-        adn_backend_cpy = self.backend.copy()
+        adn_backend_cpy = self.backend.copy_public()
         adn_backend_cpy._disconnect_line(11)
         assert not adn_backend_cpy.get_line_status()[8]
         assert not adn_backend_cpy.get_line_status()[11]
@@ -571,7 +571,7 @@ class BaseTestLoadingBackendFunc(MakeBackend):
             if i == 18:
                 # powerflow diverge if line 1 is removed, unfortunately
                 continue
-            backend_cpy = self.backend.copy()
+            backend_cpy = self.backend.copy_public()
             backend_cpy._disconnect_line(i)
             conv, *_  = backend_cpy.runpf()
             assert (
@@ -595,7 +595,7 @@ class BaseTestLoadingBackendFunc(MakeBackend):
         action = self.action_env({})  # update the action
         bk_action = self.bkact_class()
         bk_action += action
-        self.backend.apply_action(bk_action)
+        self.backend.apply_action_public(bk_action)
         after_lp, *_ = self.backend.loads_info()
         after_gp, *_ = self.backend.generators_info()
         after_ls = self.backend.get_line_status()
@@ -629,7 +629,7 @@ class BaseTestLoadingBackendFunc(MakeBackend):
         )  # update the action
         bk_action = self.bkact_class()
         bk_action += action
-        self.backend.apply_action(bk_action)
+        self.backend.apply_action_public(bk_action)
         conv, *_  = self.backend.runpf(is_dc=True)
         assert conv, f"powergrid diverge with error {_}"
         # now the system has exactly 0 losses (ie sum load = sum gen)
@@ -648,7 +648,7 @@ class BaseTestLoadingBackendFunc(MakeBackend):
         )  # update the action
         bk_action = self.bkact_class()
         bk_action += action
-        self.backend.apply_action(bk_action)
+        self.backend.apply_action_public(bk_action)
         conv, *_  = self.backend.runpf(is_dc=True)
         assert conv, "Cannot perform a powerflow after doing nothing (dc)"
 
@@ -690,7 +690,7 @@ class BaseTestLoadingBackendFunc(MakeBackend):
         )  # update the action
         bk_action = self.bkact_class()
         bk_action += action
-        self.backend.apply_action(bk_action)
+        self.backend.apply_action_public(bk_action)
         conv, *_  = self.backend.runpf(is_dc=False)
         assert conv, f"Cannot perform a powerflow after modifying the powergrid with error {_}"
 
@@ -715,7 +715,7 @@ class BaseTestLoadingBackendFunc(MakeBackend):
         bk_action += action
 
         # apply the action here
-        self.backend.apply_action(bk_action)
+        self.backend.apply_action_public(bk_action)
 
         # compute a load flow an performs more tests
         conv, *_ = self.backend.runpf()
@@ -749,7 +749,7 @@ class BaseTestLoadingBackendFunc(MakeBackend):
         bk_action = self.bkact_class()
         bk_action += action
         # apply the action here
-        self.backend.apply_action(bk_action)
+        self.backend.apply_action_public(bk_action)
 
         # compute a load flow an performs more tests
         conv, *_  = self.backend.runpf()
@@ -786,7 +786,7 @@ class BaseTestLoadingBackendFunc(MakeBackend):
         bk_action = self.bkact_class()
         bk_action += action
         # apply the action here
-        self.backend.apply_action(bk_action)
+        self.backend.apply_action_public(bk_action)
 
         # compute a load flow an performs more tests
         conv, *_  = self.backend.runpf()
@@ -878,7 +878,7 @@ class BaseTestTopoAction(MakeBackend):
         bk_action = self.bkact_class()
         bk_action += action
         # apply the action here
-        self.backend.apply_action(bk_action)
+        self.backend.apply_action_public(bk_action)
         conv, *_  = self.backend.runpf()
         assert conv, f"powerflow diverge with , error: {_}"
         after_amps_flow = self.backend.get_line_flow()
@@ -962,7 +962,7 @@ class BaseTestTopoAction(MakeBackend):
         bk_action += action
 
         # apply the action here
-        self.backend.apply_action(bk_action)
+        self.backend.apply_action_public(bk_action)
         conv, *_  = self.backend.runpf()
         assert conv, f"powerflow diverge with , error: {_}"
         after_amps_flow = self.backend.get_line_flow()
@@ -1059,7 +1059,7 @@ class BaseTestTopoAction(MakeBackend):
         bk_action = self.bkact_class()
         bk_action += action
         # apply the action here
-        self.backend.apply_action(bk_action)
+        self.backend.apply_action_public(bk_action)
 
         # run the powerflow
         conv, *_  = self.backend.runpf()
@@ -1135,7 +1135,7 @@ class BaseTestTopoAction(MakeBackend):
         bk_action += action
 
         # apply the action here
-        self.backend.apply_action(bk_action)
+        self.backend.apply_action_public(bk_action)
         conv, *_  = self.backend.runpf()
         bk_action.reset()
         assert conv, f"powerflow diverge with , error: {_}"
@@ -1198,7 +1198,7 @@ class BaseTestTopoAction(MakeBackend):
         bk_action += action
 
         # apply the action here
-        self.backend.apply_action(bk_action)
+        self.backend.apply_action_public(bk_action)
         conv, *_  = self.backend.runpf()
         assert conv, f"powerflow diverge with error: {_}"
 
@@ -1226,7 +1226,7 @@ class BaseTestTopoAction(MakeBackend):
         bk_action += action
 
         # apply the action here
-        self.backend.apply_action(bk_action)
+        self.backend.apply_action_public(bk_action)
         conv, *_  = self.backend.runpf()
         assert conv, f"powerflow diverge it should not, error: {_}"
 
@@ -1311,7 +1311,7 @@ class BaseTestTopoAction(MakeBackend):
         """function used for test_get_action_to_set"""
         bk_act = self.backend.my_bk_act_class()
         bk_act += act_set
-        self.backend.apply_action(bk_act)
+        self.backend.apply_action_public(bk_act)
         self._aux_aux_check_if_matches(prod_p, load_p, p_or, sh_q)
 
     def _aux_aux_check_if_matches(self, prod_p, load_p, p_or, sh_q):
@@ -1360,7 +1360,7 @@ class BaseTestTopoAction(MakeBackend):
         act2._dict_inj["load_p"] *= 1.5
         bk_act2 = self.backend.my_bk_act_class()
         bk_act2 += act2
-        self.backend.apply_action(bk_act2)
+        self.backend.apply_action_public(bk_act2)
         self.backend.runpf()
         prod_p2, prod_q2, prod_v2 = self.backend.generators_info()
         load_p2, load_q2, load_v2 = self.backend.loads_info()
@@ -1382,7 +1382,7 @@ class BaseTestTopoAction(MakeBackend):
         act2._set_topo_vect[act2.line_ex_pos_topo_vect[l_id]] = -1
         bk_act2 = self.backend.my_bk_act_class()
         bk_act2 += act2
-        self.backend.apply_action(bk_act2)
+        self.backend.apply_action_public(bk_act2)
         self.backend.runpf()
         p_or2, *_ = self.backend.lines_or_info()
         assert np.abs(p_or2[l_id]) <= self.tol_one, "line has not been disconnected"
@@ -1399,7 +1399,7 @@ class BaseTestTopoAction(MakeBackend):
         act2._set_topo_vect[6:9] = 2
         bk_act2 = self.backend.my_bk_act_class()
         bk_act2 += act2
-        self.backend.apply_action(bk_act2)
+        self.backend.apply_action_public(bk_act2)
         self.backend.runpf()
         p_or2, *_ = self.backend.lines_or_info()
         assert np.any(np.abs(p_or2 - p_or) >= self.tol_one)
@@ -1415,7 +1415,7 @@ class BaseTestTopoAction(MakeBackend):
             act2.shunt_q[:] = -25.0
             bk_act2 = self.backend.my_bk_act_class()
             bk_act2 += act2
-            self.backend.apply_action(bk_act2)
+            self.backend.apply_action_public(bk_act2)
             self.backend.runpf()
             prod_p2, prod_q2, prod_v2 = self.backend.generators_info()
             _, sh_q2, *_ = self.backend.shunt_info()
@@ -1449,7 +1449,7 @@ class BaseTestTopoAction(MakeBackend):
 
         bk_act2 = env2.backend.my_bk_act_class()
         bk_act2 += act
-        env2.backend.apply_action(bk_act2)
+        env2.backend.apply_action_public(bk_act2)
         env2.backend.runpf()
         assert np.all(env2.backend.storages_info()[0] == env.backend.storages_info()[0])
 
@@ -1490,7 +1490,7 @@ class BaseTestTopoAction(MakeBackend):
         act2._dict_inj["load_p"] *= 1.5
         bk_act2 = self.backend.my_bk_act_class()
         bk_act2 += act2
-        self.backend.apply_action(bk_act2)
+        self.backend.apply_action_public(bk_act2)
         self.backend.runpf()
         prod_p2, prod_q2, prod_v2 = self.backend.generators_info()
         load_p2, load_q2, load_v2 = self.backend.loads_info()
@@ -1512,7 +1512,7 @@ class BaseTestTopoAction(MakeBackend):
         act2._set_topo_vect[act2.line_ex_pos_topo_vect[l_id]] = -1
         bk_act2 = self.backend.my_bk_act_class()
         bk_act2 += act2
-        self.backend.apply_action(bk_act2)
+        self.backend.apply_action_public(bk_act2)
         self.backend.runpf()
         p_or2, *_ = self.backend.lines_or_info()
         assert np.abs(p_or2[l_id]) <= self.tol_one, "line has not been disconnected"
@@ -1529,7 +1529,7 @@ class BaseTestTopoAction(MakeBackend):
         act2._set_topo_vect[6:9] = 2
         bk_act2 = self.backend.my_bk_act_class()
         bk_act2 += act2
-        self.backend.apply_action(bk_act2)
+        self.backend.apply_action_public(bk_act2)
         self.backend.runpf()
         p_or2, *_ = self.backend.lines_or_info()
         assert np.any(np.abs(p_or2 - p_or) >= self.tol_one)
@@ -1545,7 +1545,7 @@ class BaseTestTopoAction(MakeBackend):
             act2.shunt_q[:] = -25.0
             bk_act2 = self.backend.my_bk_act_class()
             bk_act2 += act2
-            self.backend.apply_action(bk_act2)
+            self.backend.apply_action_public(bk_act2)
             self.backend.runpf()
             prod_p2, prod_q2, prod_v2 = self.backend.generators_info()
             _, sh_q2, *_ = self.backend.shunt_info()

--- a/grid2op/tests/aaa_test_backend_interface.py
+++ b/grid2op/tests/aaa_test_backend_interface.py
@@ -835,8 +835,6 @@ class AAATestBackendAPI(MakeBackend):
             # new (1.11.0) test here
             maybe_exc = backend._runpf_with_diverging_exception(is_dc=is_dc)           
             detachment_allowed = type(backend).detachment_is_allowed
-        import pdb
-        pdb.set_trace()
         if not detachment_allowed:
             # should raise in all cases as the backend prevent detachment
             self._aux_aux_test_detachment_should_fail(maybe_exc)

--- a/grid2op/tests/aaa_test_backend_interface.py
+++ b/grid2op/tests/aaa_test_backend_interface.py
@@ -51,7 +51,7 @@ class AAATestBackendAPI(MakeBackend):
         backend = self.make_backend_with_glue_code(n_busbar=n_busbar,
                                                    allow_detachment=allow_detachment,
                                                    extra_name=extra_name)
-        backend.load_grid(self.get_path(), self.get_casefile())
+        backend.load_grid_public(self.get_path(), self.get_casefile())
         backend.load_redispacthing_data("tmp")  # pretend there is no generator
         backend.load_storage_data(self.get_path())
         backend.assert_grid_correct()
@@ -84,7 +84,7 @@ class AAATestBackendAPI(MakeBackend):
         """
         self.skip_if_needed()
         backend = self.make_backend()
-        backend.load_grid(self.get_path(), self.get_casefile())  # both argument filled
+        backend.load_grid_public(self.get_path(), self.get_casefile())  # both argument filled
         backend.load_redispacthing_data(self.get_path())
         backend.load_storage_data(self.get_path())
         env_name = "BasicTest_load_grid0_" + type(self).__name__
@@ -726,7 +726,7 @@ class AAATestBackendAPI(MakeBackend):
         bk_act = type(backend).my_bk_act_class()
         bk_act += action1
         bk_act += action2
-        backend.apply_action(bk_act)  # mix of bus 1 and 2 on substation 1
+        backend.apply_action_public(bk_act)  # mix of bus 1 and 2 on substation 1
         res = backend.runpf(is_dc=False)
         assert res[0], "Your powerflow has diverged after a topology action (but should not). Check `apply_action` for topology"
         if not cls.shunts_data_available:
@@ -778,7 +778,7 @@ class AAATestBackendAPI(MakeBackend):
                                          "load_p": load_p}})
             bk_act = type(backend).my_bk_act_class()
             bk_act += action
-            backend.apply_action(bk_act)
+            backend.apply_action_public(bk_act)
             res = backend.runpf(is_dc=False)
             converged, exc_ = res
             if converged:
@@ -792,7 +792,7 @@ class AAATestBackendAPI(MakeBackend):
                                    "something like 50 (1.5**10). I suppose it's an error. "
                                    "It should stop in approx 3 iteration (so when multiplied by 1.5**3)")
                 
-        backend.reset(self.get_path(), self.get_casefile())
+        backend.reset_public(self.get_path(), self.get_casefile())
         res = backend.runpf(is_dc=False)
         assert res[0], "your backend has diverged after being reset"
         res_ref = backend2.runpf(is_dc=False)
@@ -864,17 +864,17 @@ class AAATestBackendAPI(MakeBackend):
         action.update({"set_bus": {"loads_id": [(0, 2)]}})
         bk_act = type(backend).my_bk_act_class()
         bk_act += action
-        backend.apply_action(bk_act)  # mix of bus 1 and 2 on substation 1
+        backend.apply_action_public(bk_act)  # mix of bus 1 and 2 on substation 1
         res = backend.runpf(is_dc=False)  
         self._aux_test_detachment(backend, is_dc=False)
         
-        backend.reset(self.get_path(), self.get_casefile())
+        backend.reset_public(self.get_path(), self.get_casefile())
         # a load alone on a bus
         action = type(backend)._complete_action_class()
         action.update({"set_bus": {"loads_id": [(0, 2)]}})
         bk_act = type(backend).my_bk_act_class()
         bk_act += action
-        backend.apply_action(bk_act)  # mix of bus 1 and 2 on substation 1
+        backend.apply_action_public(bk_act)  # mix of bus 1 and 2 on substation 1
         self._aux_test_detachment(backend, is_dc=True)
         
     def test_17_isolated_gen_stops_computation(self, allow_detachment=DEFAULT_ALLOW_DETACHMENT):
@@ -904,16 +904,16 @@ class AAATestBackendAPI(MakeBackend):
         action.update({"set_bus": {"generators_id": [(0, 2)]}})
         bk_act = type(backend).my_bk_act_class()
         bk_act += action
-        backend.apply_action(bk_act)  # mix of bus 1 and 2 on substation 1
+        backend.apply_action_public(bk_act)  # mix of bus 1 and 2 on substation 1
         self._aux_test_detachment(backend, is_dc=False)
         
-        backend.reset(self.get_path(), self.get_casefile())
+        backend.reset_public(self.get_path(), self.get_casefile())
         # disconnect a gen
         action = type(backend)._complete_action_class()
         action.update({"set_bus": {"generators_id": [(0, 2)]}})
         bk_act = type(backend).my_bk_act_class()
         bk_act += action
-        backend.apply_action(bk_act)  # mix of bus 1 and 2 on substation 1
+        backend.apply_action_public(bk_act)  # mix of bus 1 and 2 on substation 1
         self._aux_test_detachment(backend, is_dc=True)
         
     def test_18_isolated_shunt_stops_computation(self, allow_detachment=DEFAULT_ALLOW_DETACHMENT):
@@ -949,16 +949,16 @@ class AAATestBackendAPI(MakeBackend):
         action.update({"shunt": {"shunt_bus": [(0, 2)]}})
         bk_act = type(backend).my_bk_act_class()
         bk_act += action
-        backend.apply_action(bk_act)  # mix of bus 1 and 2 on substation 1
+        backend.apply_action_public(bk_act)  # mix of bus 1 and 2 on substation 1
         self._aux_test_detachment(backend, is_dc=False)
         
-        backend.reset(self.get_path(), self.get_casefile())
+        backend.reset_public(self.get_path(), self.get_casefile())
         # make a shunt alone on a bus
         action = type(backend)._complete_action_class()
         action.update({"shunt": {"shunt_bus": [(0, 2)]}})
         bk_act = type(backend).my_bk_act_class()
         bk_act += action
-        backend.apply_action(bk_act)  # mix of bus 1 and 2 on substation 1
+        backend.apply_action_public(bk_act)  # mix of bus 1 and 2 on substation 1
         self._aux_test_detachment(backend, is_dc=True)
         
     def test_19_isolated_storage_stops_computation(self, allow_detachment=DEFAULT_ALLOW_DETACHMENT):
@@ -989,15 +989,15 @@ class AAATestBackendAPI(MakeBackend):
         action.update({"set_bus": {"storages_id": [(0, 2)]}})
         bk_act = type(backend).my_bk_act_class()
         bk_act += action
-        backend.apply_action(bk_act)  # mix of bus 1 and 2 on substation 1
+        backend.apply_action_public(bk_act)  # mix of bus 1 and 2 on substation 1
         self._aux_test_detachment(backend, is_dc=False)
         
-        backend.reset(self.get_path(), self.get_casefile())
+        backend.reset_public(self.get_path(), self.get_casefile())
         action = type(backend)._complete_action_class()
         action.update({"set_bus": {"storages_id": [(0, 2)]}})
         bk_act = type(backend).my_bk_act_class()
         bk_act += action
-        backend.apply_action(bk_act)  # mix of bus 1 and 2 on substation 1
+        backend.apply_action_public(bk_act)  # mix of bus 1 and 2 on substation 1
         self._aux_test_detachment(backend, is_dc=True)
         
     def test_20_disconnected_load_stops_computation(self, allow_detachment=DEFAULT_ALLOW_DETACHMENT):
@@ -1027,16 +1027,16 @@ class AAATestBackendAPI(MakeBackend):
         action.update({"set_bus": {"loads_id": [(0, -1)]}})
         bk_act = type(backend).my_bk_act_class()
         bk_act += action
-        backend.apply_action(bk_act)  # mix of bus 1 and 2 on substation 1
+        backend.apply_action_public(bk_act)  # mix of bus 1 and 2 on substation 1
         self._aux_test_detachment(backend, is_dc=False, detachment_should_pass=True)
         
-        backend.reset(self.get_path(), self.get_casefile())
+        backend.reset_public(self.get_path(), self.get_casefile())
         # a load alone on a bus
         action = type(backend)._complete_action_class()
         action.update({"set_bus": {"loads_id": [(0, -1)]}})
         bk_act = type(backend).my_bk_act_class()
         bk_act += action
-        backend.apply_action(bk_act)  # mix of bus 1 and 2 on substation 1
+        backend.apply_action_public(bk_act)  # mix of bus 1 and 2 on substation 1
         self._aux_test_detachment(backend, is_dc=True, detachment_should_pass=True)
              
     def test_21_disconnected_gen_stops_computation(self, allow_detachment=DEFAULT_ALLOW_DETACHMENT):
@@ -1066,16 +1066,16 @@ class AAATestBackendAPI(MakeBackend):
         action.update({"set_bus": {"generators_id": [(0, -1)]}})
         bk_act = type(backend).my_bk_act_class()
         bk_act += action
-        backend.apply_action(bk_act)  # mix of bus 1 and 2 on substation 1
+        backend.apply_action_public(bk_act)  # mix of bus 1 and 2 on substation 1
         self._aux_test_detachment(backend, is_dc=False, detachment_should_pass=True)
         
-        backend.reset(self.get_path(), self.get_casefile())
+        backend.reset_public(self.get_path(), self.get_casefile())
         # a disconnected generator
         action = type(backend)._complete_action_class()
         action.update({"set_bus": {"generators_id": [(0, -1)]}})
         bk_act = type(backend).my_bk_act_class()
         bk_act += action
-        backend.apply_action(bk_act)  # mix of bus 1 and 2 on substation 1
+        backend.apply_action_public(bk_act)  # mix of bus 1 and 2 on substation 1
         self._aux_test_detachment(backend, is_dc=True, detachment_should_pass=True)
         
     def test_22_islanded_grid_stops_computation(self):
@@ -1105,23 +1105,23 @@ class AAATestBackendAPI(MakeBackend):
                                    "lines_ex_id": [(7, 2), (14, 2)]}})
         bk_act = type(backend).my_bk_act_class()
         bk_act += action
-        backend.apply_action(bk_act)  # mix of bus 1 and 2 on substation 1
+        backend.apply_action_public(bk_act)  # mix of bus 1 and 2 on substation 1
         res = backend.runpf(is_dc=False)  
         assert not res[0], f"It is expected that your backend return `(False, _)` in case of non connected grid in AC."                 
         error = res[1]
         assert isinstance(error, Grid2OpException), f"When your backend return `False`, we expect it throws an exception inheriting from Grid2OpException (second return value), backend returned {type(error)}"  
         if not isinstance(error, BackendError):
             warnings.warn("The error returned by your backend when it stopped (due to non connected grid) should preferably inherit from BackendError")
-        backend.reset(self.get_path(), self.get_casefile())
+        backend.reset_public(self.get_path(), self.get_casefile())
         
         # a non connected grid
-        backend.reset(self.get_path(), self.get_casefile())
+        backend.reset_public(self.get_path(), self.get_casefile())
         action = type(backend)._complete_action_class()
         action.update({"set_bus": {"lines_or_id": [(17, 2)],
                                    "lines_ex_id": [(7, 2), (14, 2)]}})
         bk_act = type(backend).my_bk_act_class()
         bk_act += action
-        backend.apply_action(bk_act)  # mix of bus 1 and 2 on substation 1
+        backend.apply_action_public(bk_act)  # mix of bus 1 and 2 on substation 1
         res = backend.runpf(is_dc=True)  
         assert not res[0], f"It is expected that your backend return `(False, _)` in case of non connected grid in DC."                    
         error = res[1]
@@ -1149,7 +1149,7 @@ class AAATestBackendAPI(MakeBackend):
         action.update({"set_bus": {"lines_or_id": [(line_id, -1)]}})
         bk_act = type(backend).my_bk_act_class()
         bk_act += action
-        backend.apply_action(bk_act)
+        backend.apply_action_public(bk_act)
         
         res = backend.runpf(is_dc=False)  
         assert res[0], f"Your backend diverged in AC after a line disconnection, error was {res[1]}"   
@@ -1161,12 +1161,12 @@ class AAATestBackendAPI(MakeBackend):
         assert np.allclose(a_ex[line_id], 0.), f"v_ex should be 0. for disconnected line, but is currently {v_ex[line_id]} (AC)" 
         
         # reset and do the same in DC
-        backend.reset(self.get_path(), self.get_casefile())
+        backend.reset_public(self.get_path(), self.get_casefile())
         action = type(backend)._complete_action_class()
         action.update({"set_bus": {"lines_or_id": [(line_id, -1)]}})
         bk_act = type(backend).my_bk_act_class()
         bk_act += action
-        backend.apply_action(bk_act)
+        backend.apply_action_public(bk_act)
         
         res = backend.runpf(is_dc=True)  
         assert res[0],  f"Your backend diverged in DC after a line disconnection, error was {res[1]}"    
@@ -1204,7 +1204,7 @@ class AAATestBackendAPI(MakeBackend):
         action.update({"shunt": {"shunt_bus": [(shunt_id, -1)]}})
         bk_act = type(backend).my_bk_act_class()
         bk_act += action
-        backend.apply_action(bk_act)
+        backend.apply_action_public(bk_act)
         res = backend.runpf(is_dc=False)  
         assert res[0],  f"Your backend diverged in AC after a shunt disconnection, error was {res[1]}"    
         p_, q_, v_, bus_ = backend.shunt_info()
@@ -1212,12 +1212,12 @@ class AAATestBackendAPI(MakeBackend):
         assert bus_[shunt_id] == -1, f"bus_ should be -1 for disconnected shunt, but is currently {bus_[shunt_id]} (AC)" 
         
         # a disconnected shunt
-        backend.reset(self.get_path(), self.get_casefile())
+        backend.reset_public(self.get_path(), self.get_casefile())
         action = type(backend)._complete_action_class()
         action.update({"shunt": {"shunt_bus": [(shunt_id, -1)]}})
         bk_act = type(backend).my_bk_act_class()
         bk_act += action
-        backend.apply_action(bk_act)
+        backend.apply_action_public(bk_act)
         res = backend.runpf(is_dc=True)  
         assert res[0],  f"Your backend diverged in DC after a shunt disconnection, error was {res[1]}"    
         p_, q_, v_, bus_ = backend.shunt_info()
@@ -1249,7 +1249,7 @@ class AAATestBackendAPI(MakeBackend):
         action.update({"set_bus": {"storages_id": [(storage_id, -1)]}})
         bk_act = type(backend).my_bk_act_class()
         bk_act += action
-        backend.apply_action(bk_act)
+        backend.apply_action_public(bk_act)
         
         res = backend.runpf(is_dc=False)  
         assert res[0],  f"Your backend diverged in AC after a storage disconnection, error was {res[1]}"    
@@ -1257,12 +1257,12 @@ class AAATestBackendAPI(MakeBackend):
         assert np.allclose(v_[storage_id], 0.), f"v should be 0. for disconnected storage, but is currently {v_[storage_id]} (AC)" 
         
         # disconnect a storage
-        backend.reset(self.get_path(), self.get_casefile())
+        backend.reset_public(self.get_path(), self.get_casefile())
         action = type(backend)._complete_action_class()
         action.update({"set_bus": {"storages_id": [(storage_id, -1)]}})
         bk_act = type(backend).my_bk_act_class()
         bk_act += action
-        backend.apply_action(bk_act)
+        backend.apply_action_public(bk_act)
         res = backend.runpf(is_dc=True)  
         assert res[0],  f"Your backend diverged in DC after a storage disconnection, error was {res[1]}"    
         p_, q_, v_ = backend.storages_info()
@@ -1288,11 +1288,11 @@ class AAATestBackendAPI(MakeBackend):
         backend = self.aux_make_backend()
         if not backend._can_be_copied:
             with self.assertRaises(BackendError):
-                backend_cpy = backend.copy()
+                backend_cpy = backend.copy_public()
             return
         
         # backend can be copied
-        backend_cpy = backend.copy()
+        backend_cpy = backend.copy_public()
         assert isinstance(backend_cpy, type(backend)), f"backend.copy() is supposed to return an object of the same type as your backend. Check backend.copy()"
         res = backend.runpf(is_dc=False)
         assert res[0],  f"Your backend diverged in AC after a copy, error was {res[1]}"    
@@ -1305,7 +1305,7 @@ class AAATestBackendAPI(MakeBackend):
                                      "load_p": 1.1 * init_load_p}})
         bk_act = type(backend).my_bk_act_class()
         bk_act += action
-        backend.apply_action(bk_act)
+        backend.apply_action_public(bk_act)
         res = backend.runpf(is_dc=True) 
         res_cpy = backend_cpy.runpf(is_dc=True) 
         assert res_cpy[0],  f"Your backend diverged in DC after a copy, error was {res_cpy[1]}"    
@@ -1342,12 +1342,12 @@ class AAATestBackendAPI(MakeBackend):
         
         # disconnect line
         line_id = 0
-        backend.reset(self.get_path(), self.get_casefile())
+        backend.reset_public(self.get_path(), self.get_casefile())
         action = type(backend)._complete_action_class()
         action.update({"set_line_status": [(line_id, -1)]})
         bk_act = type(backend).my_bk_act_class()
         bk_act += action
-        backend.apply_action(bk_act)
+        backend.apply_action_public(bk_act)
         res = backend.runpf(is_dc=False)  
         assert res[0],  f"Your backend diverged in AC after a line disconnection, error was {res[1]}"    
         topo_vect = self._aux_check_topo_vect(backend)
@@ -1361,12 +1361,12 @@ class AAATestBackendAPI(MakeBackend):
         # disconnect storage
         if cls.n_storage > 0:
             sto_id = 0
-            backend.reset(self.get_path(), self.get_casefile())
+            backend.reset_public(self.get_path(), self.get_casefile())
             action = type(backend)._complete_action_class()
             action.update({"set_bus": {"storages_id": [(sto_id, -1)]}})
             bk_act = type(backend).my_bk_act_class()
             bk_act += action
-            backend.apply_action(bk_act)
+            backend.apply_action_public(bk_act)
             res = backend.runpf(is_dc=False)  
             assert res[0],  f"Your backend diverged in AC after a storage disconnection, error was {res[1]}"    
             topo_vect = self._aux_check_topo_vect(backend)
@@ -1384,12 +1384,12 @@ class AAATestBackendAPI(MakeBackend):
         else:
             # so cls.shunts_data_available and cls.n_shunt >= 1
             shunt_id = 0
-            backend.reset(self.get_path(), self.get_casefile())
+            backend.reset_public(self.get_path(), self.get_casefile())
             action = type(backend)._complete_action_class()
             action.update({"shunt": {"shunt_bus": [(shunt_id, -1)]}})
             bk_act = type(backend).my_bk_act_class()
             bk_act += action
-            backend.apply_action(bk_act)
+            backend.apply_action_public(bk_act)
             res = backend.runpf(is_dc=False)  
             assert res[0],  f"Your backend diverged in AC after a shunt disconnection, error was {res[1]}"    
             topo_vect = self._aux_check_topo_vect(backend)
@@ -1476,7 +1476,7 @@ class AAATestBackendAPI(MakeBackend):
                         }})
         bk_act = type(backend).my_bk_act_class()
         bk_act += action  # "compile" all the user action into one single action sent to the backend
-        backend.apply_action(bk_act)  # apply the action
+        backend.apply_action_public(bk_act)  # apply the action
         res = backend.runpf(is_dc=False)  
         assert res[0],  f"Your backend diverged in AC after setting a {el_nm} on busbar {busbar_id}, error was {res[1]}"    
         # now check the topology vector
@@ -1510,12 +1510,12 @@ class AAATestBackendAPI(MakeBackend):
         # line or
         line_id = 0
         busbar_id = 2
-        backend.reset(self.get_path(), self.get_casefile())
+        backend.reset_public(self.get_path(), self.get_casefile())
         action = type(backend)._complete_action_class()
         action.update({"set_bus": {"lines_or_id": [(line_id, busbar_id)]}})
         bk_act = type(backend).my_bk_act_class()
         bk_act += action
-        backend.apply_action(bk_act)
+        backend.apply_action_public(bk_act)
         res = backend.runpf(is_dc=False)  
         assert res[0],  f"Your backend diverged in AC after setting a line (or side) on busbar 2, error was {res[1]}"    
         topo_vect = self._aux_check_topo_vect(backend)
@@ -1526,12 +1526,12 @@ class AAATestBackendAPI(MakeBackend):
         # line ex
         line_id = 0
         busbar_id = 2
-        backend.reset(self.get_path(), self.get_casefile())
+        backend.reset_public(self.get_path(), self.get_casefile())
         action = type(backend)._complete_action_class()
         action.update({"set_bus": {"lines_ex_id": [(line_id, busbar_id)]}})
         bk_act = type(backend).my_bk_act_class()
         bk_act += action
-        backend.apply_action(bk_act)
+        backend.apply_action_public(bk_act)
         res = backend.runpf(is_dc=False)  
         assert res[0],  f"Your backend diverged in AC after setting a line (ex side) on busbar 2, error was {res[1]}"    
         topo_vect = self._aux_check_topo_vect(backend)
@@ -1540,7 +1540,7 @@ class AAATestBackendAPI(MakeBackend):
         assert topo_vect[cls.line_ex_pos_topo_vect[line_id]] == busbar_id, error_msg
         
         # load
-        backend.reset(self.get_path(), self.get_casefile())
+        backend.reset_public(self.get_path(), self.get_casefile())
         busbar_id = 2
         nb_el = cls.n_load
         el_to_subid = cls.load_to_subid
@@ -1551,7 +1551,7 @@ class AAATestBackendAPI(MakeBackend):
                                    el_nm, el_key, el_pos_topo_vect)
         
         # generator
-        backend.reset(self.get_path(), self.get_casefile())
+        backend.reset_public(self.get_path(), self.get_casefile())
         busbar_id = 2
         nb_el = cls.n_gen
         el_to_subid = cls.gen_to_subid
@@ -1563,7 +1563,7 @@ class AAATestBackendAPI(MakeBackend):
         
         # storage
         if cls.n_storage > 0:
-            backend.reset(self.get_path(), self.get_casefile())
+            backend.reset_public(self.get_path(), self.get_casefile())
             busbar_id = 2
             nb_el = cls.n_storage
             el_to_subid = cls.storage_to_subid
@@ -1625,12 +1625,12 @@ class AAATestBackendAPI(MakeBackend):
         # line or
         line_id = 0
         busbar_id = n_busbar
-        backend.reset(self.get_path(), self.get_casefile())
+        backend.reset_public(self.get_path(), self.get_casefile())
         action = cls._complete_action_class()
         action.update({"set_bus": {"lines_or_id": [(line_id, busbar_id)]}})
         bk_act = cls.my_bk_act_class()
         bk_act += action
-        backend.apply_action(bk_act)
+        backend.apply_action_public(bk_act)
         res = backend.runpf(is_dc=False)  
         assert res[0],  f"Your backend diverged in AC after setting a line (or side) on busbar 3, error was {res[1]}"    
         topo_vect = self._aux_check_topo_vect(backend)
@@ -1641,12 +1641,12 @@ class AAATestBackendAPI(MakeBackend):
         # line ex
         line_id = 0
         busbar_id = n_busbar
-        backend.reset(self.get_path(), self.get_casefile())
+        backend.reset_public(self.get_path(), self.get_casefile())
         action = cls._complete_action_class()
         action.update({"set_bus": {"lines_ex_id": [(line_id, busbar_id)]}})
         bk_act = cls.my_bk_act_class()
         bk_act += action
-        backend.apply_action(bk_act)
+        backend.apply_action_public(bk_act)
         res = backend.runpf(is_dc=False)  
         assert res[0],  f"Your backend diverged in AC after setting a line (ex side) on busbar 3, error was {res[1]}"    
         topo_vect = self._aux_check_topo_vect(backend)
@@ -1655,7 +1655,7 @@ class AAATestBackendAPI(MakeBackend):
         assert topo_vect[cls.line_ex_pos_topo_vect[line_id]] == busbar_id, error_msg
         
         # load
-        backend.reset(self.get_path(), self.get_casefile())
+        backend.reset_public(self.get_path(), self.get_casefile())
         busbar_id = n_busbar
         nb_el = cls.n_load
         el_to_subid = cls.load_to_subid
@@ -1666,7 +1666,7 @@ class AAATestBackendAPI(MakeBackend):
                                    el_nm, el_key, el_pos_topo_vect)
         
         # generator
-        backend.reset(self.get_path(), self.get_casefile())
+        backend.reset_public(self.get_path(), self.get_casefile())
         busbar_id = n_busbar
         nb_el = cls.n_gen
         el_to_subid = cls.gen_to_subid
@@ -1678,7 +1678,7 @@ class AAATestBackendAPI(MakeBackend):
         
         # storage
         if cls.n_storage > 0:
-            backend.reset(self.get_path(), self.get_casefile())
+            backend.reset_public(self.get_path(), self.get_casefile())
             busbar_id = n_busbar
             nb_el = cls.n_storage
             el_to_subid = cls.storage_to_subid
@@ -1695,12 +1695,12 @@ class AAATestBackendAPI(MakeBackend):
         action.update({"set_bus": {"storages_id": [(0, -1)]}})
         bk_act = type(backend).my_bk_act_class()
         bk_act += action
-        backend.apply_action(bk_act)
+        backend.apply_action_public(bk_act)
         action = type(backend)._complete_action_class()
         action.update({"set_storage": [(0, 0.1)]})
         bk_act = type(backend).my_bk_act_class()
         bk_act += action
-        backend.apply_action(bk_act)
+        backend.apply_action_public(bk_act)
         
     def test_31_disconnected_storage_with_p_stops_computation(self, allow_detachment=DEFAULT_ALLOW_DETACHMENT):
         """
@@ -1732,7 +1732,7 @@ class AAATestBackendAPI(MakeBackend):
         self._aux_disco_sto_then_add_sto_p(backend)
         self._aux_test_detachment(backend, is_dc=False, detachment_should_pass=True)
         
-        backend.reset(self.get_path(), self.get_casefile())
+        backend.reset_public(self.get_path(), self.get_casefile())
         # a disconnected generator
         self._aux_disco_sto_then_add_sto_p(backend)
         self._aux_test_detachment(backend, is_dc=True, detachment_should_pass=True)
@@ -1779,6 +1779,7 @@ class AAATestBackendAPI(MakeBackend):
         """    
         self.skip_if_needed()
         backend = self.aux_make_backend(allow_detachment=True)
+        cls = type(backend)
         if backend._missing_detachment_support_info:
             self.skipTest("Cannot perform this test as you have not specified whether "
                           "the backend class supports the 'detachement' of loads and "
@@ -1791,10 +1792,12 @@ class AAATestBackendAPI(MakeBackend):
         self.test_16_isolated_load_stops_computation(allow_detachment=True)
         self.test_17_isolated_gen_stops_computation(allow_detachment=True)
         self.test_18_isolated_shunt_stops_computation(allow_detachment=True)
-        self.test_19_isolated_storage_stops_computation(allow_detachment=True)
+        if cls.n_storage > 0:
+            self.test_19_isolated_storage_stops_computation(allow_detachment=True)
         self.test_20_disconnected_load_stops_computation(allow_detachment=True)
         self.test_21_disconnected_gen_stops_computation(allow_detachment=True)
-        self.test_31_disconnected_storage_with_p_stops_computation(allow_detachment=True)
+        if cls.n_storage > 0:
+            self.test_31_disconnected_storage_with_p_stops_computation(allow_detachment=True)
     
     # TODO test: gen_v of disconnected generator are 0
     # TODO test : load_v of disco load are 0

--- a/grid2op/tests/aaa_test_backend_interface.py
+++ b/grid2op/tests/aaa_test_backend_interface.py
@@ -58,11 +58,11 @@ class AAATestBackendAPI(MakeBackend):
         try:
             
             topo_ = backend.get_topo_vect()
-            cls = type(cls)
+            cls = type(backend)
             self.backend.update_bus_target_after_pf(topo_[cls.load_pos_topo_vect],
                                                     topo_[cls.gen_pos_topo_vect],
                                                     topo_[cls.storage_pos_topo_vect])
-        except :
+        except Grid2OpException as exc_:
             # impossible to retrieve the topology without running a powerflow
             backend.update_bus_target_after_pf(1, 1, 1)
         return backend

--- a/grid2op/tests/aaa_test_backend_interface.py
+++ b/grid2op/tests/aaa_test_backend_interface.py
@@ -59,9 +59,9 @@ class AAATestBackendAPI(MakeBackend):
             
             topo_ = backend.get_topo_vect()
             cls = type(backend)
-            self.backend.update_bus_target_after_pf(topo_[cls.load_pos_topo_vect],
-                                                    topo_[cls.gen_pos_topo_vect],
-                                                    topo_[cls.storage_pos_topo_vect])
+            backend.update_bus_target_after_pf(topo_[cls.load_pos_topo_vect],
+                                               topo_[cls.gen_pos_topo_vect],
+                                               topo_[cls.storage_pos_topo_vect])
         except Grid2OpException as exc_:
             # impossible to retrieve the topology without running a powerflow
             backend.update_bus_target_after_pf(1, 1, 1)

--- a/grid2op/tests/test_Action.py
+++ b/grid2op/tests/test_Action.py
@@ -1409,7 +1409,6 @@ class TestActionBase(ABC):
         assert np.all(
             res.line_ex_pos_topo_vect == self.helper_action.line_ex_pos_topo_vect
         )
-        # pdb.set_trace()
         assert issubclass(res.actionClass, self.helper_action._init_subtype)
 
     def test_json_serializable(self):

--- a/grid2op/tests/test_AgentsFast.py
+++ b/grid2op/tests/test_AgentsFast.py
@@ -71,8 +71,6 @@ class TestAgentFaster(HelperTests, unittest.TestCase):
             cum_reward += reward
             # print("reward: {}".format(reward))
             # print("_______________")
-            # if reward <= 0 or np.any(obs.prod_p < 0):
-            #     pdb.set_trace()
             i += 1
             if i > i_max:
                 break

--- a/grid2op/tests/test_ChronicsHandler.py
+++ b/grid2op/tests/test_ChronicsHandler.py
@@ -394,7 +394,7 @@ class TestLoadingChronicsHandler(HelperTests, unittest.TestCase):
         backend = PandaPowerBackend()
         path_matpower = PATH_DATA_TEST_PP
         case_file = "test_case14.json"
-        backend.load_grid(path_matpower, case_file)
+        backend.load_grid_public(path_matpower, case_file)
         chron_handl.check_validity(backend)
 
     def test_chronicsloading(self):
@@ -612,7 +612,7 @@ class TestLoadingChronicsHandlerWithForecast(HelperTests, unittest.TestCase):
         backend = PandaPowerBackend()
         path_matpower = PATH_DATA_TEST_PP
         case_file = "test_case14.json"
-        backend.load_grid(path_matpower, case_file)
+        backend.load_grid_public(path_matpower, case_file)
         chron_handl.check_validity(backend)
 
 
@@ -749,7 +749,7 @@ class TestLoadingChronicsHandlerPP(HelperTests, unittest.TestCase):
         backend = PandaPowerBackend()
         path_matpower = PATH_DATA_TEST_PP
         case_file = "test_case14.json"
-        backend.load_grid(path_matpower, case_file)
+        backend.load_grid_public(path_matpower, case_file)
         chron_handl.check_validity(backend)
 
     def test_check_validity_withdiffname(self):
@@ -765,7 +765,7 @@ class TestLoadingChronicsHandlerPP(HelperTests, unittest.TestCase):
         backend = PandaPowerBackend()
         path_matpower = PATH_DATA_TEST_PP
         case_file = "test_case14.json"
-        backend.load_grid(path_matpower, case_file)
+        backend.load_grid_public(path_matpower, case_file)
         chron_handl.check_validity(backend)
 
     def test_chronicsloading(self):

--- a/grid2op/tests/test_ObservationHazard_Maintenance.py
+++ b/grid2op/tests/test_ObservationHazard_Maintenance.py
@@ -46,7 +46,6 @@ class TestObservationHazard(unittest.TestCase):
         self.tolvect = 1e-2
         self.tol_one = 1e-5
         self.game_rules = RulesChecker()
-        # pdb.set_trace()
         self.rewardClass = L2RPNReward
         self.reward_helper = self.rewardClass()
         self.obsClass = CompleteObservation

--- a/grid2op/tests/test_ObservationHazard_Maintenance.py
+++ b/grid2op/tests/test_ObservationHazard_Maintenance.py
@@ -47,7 +47,7 @@ class TestObservationHazard(unittest.TestCase):
         # self.backend = ADNBackend()
         # self.path_matpower = "/home/donnotben/Documents/RL4Grid/RL4Grid/data"
         # self.case_file = "ieee14_ADN.xml"
-        # self.backend.load_grid(self.path_matpower, self.case_file)
+        # self.backend.load_grid_public(self.path_matpower, self.case_file)
         self.tolvect = 1e-2
         self.tol_one = 1e-5
         self.game_rules = RulesChecker()

--- a/grid2op/tests/test_ObservationHazard_Maintenance.py
+++ b/grid2op/tests/test_ObservationHazard_Maintenance.py
@@ -43,11 +43,6 @@ class TestObservationHazard(unittest.TestCase):
         The case file is a representation of the case14 as found in the ieee14 powergrid.
         :return:
         """
-        # from ADNBackend import ADNBackend
-        # self.backend = ADNBackend()
-        # self.path_matpower = "/home/donnotben/Documents/RL4Grid/RL4Grid/data"
-        # self.case_file = "ieee14_ADN.xml"
-        # self.backend.load_grid_public(self.path_matpower, self.case_file)
         self.tolvect = 1e-2
         self.tol_one = 1e-5
         self.game_rules = RulesChecker()

--- a/grid2op/tests/test_Rules.py
+++ b/grid2op/tests/test_Rules.py
@@ -657,7 +657,6 @@ class TestReconnectionsLegality(unittest.TestCase):
         # this is not supposed to reconnect it either (cooldown)
         assert obs.time_before_cooldown_line[l_id] == 2
         obs, reward, done, info = env.step(set_or_1_act)
-        # pdb.set_trace()
         # assert info["is_illegal"]
         assert env.backend._grid.line.iloc[l_id]["in_service"] == False
         assert obs.rho[l_id] == 0.0

--- a/grid2op/tests/test_bug_shunt_dc.py
+++ b/grid2op/tests/test_bug_shunt_dc.py
@@ -36,7 +36,7 @@ class AuxTestBugShuntDC:
     
     def _aux_modify_shunt(self):
         self.bk_act += self.env.action_space({"shunt": {"set_bus": np.array([2], dtype=int)}})
-        self.env.backend.apply_action(self.bk_act)
+        self.env.backend.apply_action_public(self.bk_act)
         if isinstance(self.env.backend, PandaPowerBackend):
             assert self.env.backend._grid.shunt["bus"][0] == 22
             assert self.env.backend._grid.bus["in_service"][self.env.backend._grid.shunt["bus"][0]]

--- a/grid2op/tests/test_detached_simulate.py
+++ b/grid2op/tests/test_detached_simulate.py
@@ -15,8 +15,7 @@ import unittest
 import warnings
 import numpy as np
 import pdb
-# from pypowsybl2grid import PyPowSyBlBackend
-# from lightsim2grid import LightSimBackend
+
 
 class TestDetachSimulate(unittest.TestCase):
     def setUp(self):
@@ -29,7 +28,6 @@ class TestDetachSimulate(unittest.TestCase):
                                     _add_to_name=type(self).__name__,
                                     chronics_class=ChangeNothing,
                                     data_feeding_kwargs={"h_forecast": [5, 10, 15, 20, 25, 30]},
-                                    # backend=PyPowSyBlBackend()
                                     )
         paramerters = self.env.parameters
         paramerters.MAX_SUB_CHANGED = 99999

--- a/grid2op/tests/test_issue_561.py
+++ b/grid2op/tests/test_issue_561.py
@@ -33,8 +33,8 @@ class Issue561Tester(unittest.TestCase):
         obs_init = env.reset()
         assert not type(obs_init).shunts_data_available
         assert not type(env.backend).shunts_data_available
-        backend = env.backend.copy()
-        backend1 = env.backend.copy()
+        backend = env.backend.copy_public()
+        backend1 = env.backend.copy_public()
         obs, *_ = env.step(env.action_space())
         obs.load_p[:] += 1.  # to make sure everything changes
         backend.update_from_obs(obs)

--- a/grid2op/tests/test_n_busbar_per_sub.py
+++ b/grid2op/tests/test_n_busbar_per_sub.py
@@ -1157,7 +1157,7 @@ class TestPandapowerBackend_3busbars(unittest.TestCase):
                 act = self.env.action_space({"set_bus": {"loads_id": [(el_id, new_bus)], "lines_ex_id": [(line_ex_id, new_bus)]}})
             bk_act = self.env._backend_action_class()
             bk_act += act
-            self.env.backend.apply_action(bk_act)
+            self.env.backend.apply_action_public(bk_act)
             global_bus = sub_id + (new_bus -1) * cls.n_sub 
             if new_bus >= 1:
                 assert self.env.backend._grid.load.iloc[el_id]["bus"] == global_bus
@@ -1189,7 +1189,7 @@ class TestPandapowerBackend_3busbars(unittest.TestCase):
                 act = self.env.action_space({"set_bus": {"generators_id": [(el_id, new_bus)], "lines_ex_id": [(line_ex_id, new_bus)]}})
             bk_act = self.env._backend_action_class()
             bk_act += act
-            self.env.backend.apply_action(bk_act)
+            self.env.backend.apply_action_public(bk_act)
             global_bus = sub_id + (new_bus -1) * cls.n_sub 
             if new_bus >= 1:
                 assert self.env.backend._grid.gen.iloc[el_id]["bus"] == global_bus
@@ -1221,7 +1221,7 @@ class TestPandapowerBackend_3busbars(unittest.TestCase):
                 act = self.env.action_space({"set_bus": {"storages_id": [(el_id, new_bus)], "lines_ex_id": [(line_ex_id, new_bus)]}})
             bk_act = self.env._backend_action_class()
             bk_act += act
-            self.env.backend.apply_action(bk_act)
+            self.env.backend.apply_action_public(bk_act)
             global_bus = sub_id + (new_bus -1) * cls.n_sub 
             if new_bus >= 1:
                 assert self.env.backend._grid.storage.iloc[el_id]["bus"] == global_bus
@@ -1247,7 +1247,7 @@ class TestPandapowerBackend_3busbars(unittest.TestCase):
             act = self.env.action_space({"set_bus": {"lines_or_id": [(line_id, new_bus)]}})
             bk_act = self.env._backend_action_class()
             bk_act += act
-            self.env.backend.apply_action(bk_act)
+            self.env.backend.apply_action_public(bk_act)
             global_bus = cls.line_or_to_subid[line_id] + (new_bus -1) * cls.n_sub 
             if new_bus >= 1:
                 assert self.env.backend._grid.line.iloc[line_id]["from_bus"] == global_bus
@@ -1268,7 +1268,7 @@ class TestPandapowerBackend_3busbars(unittest.TestCase):
             act = self.env.action_space({"set_bus": {"lines_ex_id": [(line_id, new_bus)]}})
             bk_act = self.env._backend_action_class()
             bk_act += act
-            self.env.backend.apply_action(bk_act)
+            self.env.backend.apply_action_public(bk_act)
             global_bus = cls.line_ex_to_subid[line_id] + (new_bus -1) * cls.n_sub 
             if new_bus >= 1:
                 assert self.env.backend._grid.line.iloc[line_id]["to_bus"] == global_bus
@@ -1296,7 +1296,7 @@ class TestPandapowerBackend_3busbars(unittest.TestCase):
                 act = self.env.action_space({"shunt": {"set_bus": [(el_id, new_bus)]}, "set_bus": {"lines_ex_id": [(line_ex_id, new_bus)]}})
             bk_act = self.env._backend_action_class()
             bk_act += act
-            self.env.backend.apply_action(bk_act)
+            self.env.backend.apply_action_public(bk_act)
             global_bus = sub_id + (new_bus -1) * cls.n_sub 
             if new_bus >= 1:
                 assert self.env.backend._grid.shunt.iloc[el_id]["bus"] == global_bus
@@ -1328,7 +1328,7 @@ class TestPandapowerBackend_3busbars(unittest.TestCase):
                 act = self.env.action_space({"set_bus": {"loads_id": [(el_id, new_bus)], "lines_ex_id": [(line_ex_id, new_bus)]}})
             bk_act = self.env._backend_action_class()
             bk_act += act
-            self.env.backend.apply_action(bk_act)
+            self.env.backend.apply_action_public(bk_act)
             conv, maybe_exc = self.env.backend.runpf()
             assert conv, f"error : {maybe_exc}"
             p_subs, q_subs, p_bus, q_bus, diff_v_bus = self.env.backend.check_kirchhoff()

--- a/grid2op/tests/test_simulator.py
+++ b/grid2op/tests/test_simulator.py
@@ -53,10 +53,10 @@ class TestSimulator(unittest.TestCase):
         simulator = Simulator(backend=self.env.backend)
         with self.assertRaises(SimulatorError):
             # not initialized
-            simulator.change_backend(self.env.backend.copy())
+            simulator.change_backend(self.env.backend.copy_public())
 
         simulator.set_state(self.obs)
-        simulator.change_backend(self.env.backend.copy())
+        simulator.change_backend(self.env.backend.copy_public())
 
         with self.assertRaises(SimulatorError):
             # env is not a BaseEnv
@@ -67,7 +67,7 @@ class TestSimulator(unittest.TestCase):
         with self.assertRaises(SimulatorError):
             # not initialized
             simulator.change_backend_type(
-                self.env.backend.copy(), grid_path=self.env._init_grid_path
+                self.env.backend.copy_public(), grid_path=self.env._init_grid_path
             )
 
         simulator.set_state(self.obs)

--- a/grid2op/utils/underlying_statistics.py
+++ b/grid2op/utils/underlying_statistics.py
@@ -804,7 +804,4 @@ if __name__ == "__main__":
     # rho_dn, ids = stats_dn.get("rho")
     score_op_cost, ids = stats_dn.get("grid_operational_cost_scores")
     score_att_cost, ids = stats_dn.get("operator_attention_scores")
-    import pdb
-
-    pdb.set_trace()
     assert score_att_cost.shape[0] == ids.shape[0]


### PR DESCRIPTION
Refactor and rationalize the "public / protected" backend API:

- copy
- load_grid
- reset
- apply_action

are now "private" backend API and never called directly by the environment.

The environment calls, instead:

- copy_public
- load_grid_public
- reset_public
- apply_action_public