### PR TITLE
feat: Make env using custom config file path in kwargs

### DIFF
--- a/grid2op/MakeEnv/MakeFromPath.py
+++ b/grid2op/MakeEnv/MakeFromPath.py
@@ -339,7 +339,10 @@ def make_from_dataset_path(
     _check_kwargs(kwargs)
 
     # Compute and find config file
-    config_path_abs = os.path.abspath(os.path.join(dataset_path_abs, NAME_CONFIG_FILE))
+    if "_config_path" in kwargs:
+        config_path_abs = os.path.abspath(kwargs["_config_path"])
+    else:
+        config_path_abs = os.path.abspath(os.path.join(dataset_path_abs, NAME_CONFIG_FILE))
     _check_path(config_path_abs, "Dataset environment configuration")
 
     # Read config file


### PR DESCRIPTION
Specify custom config.py file using kwargs. Related to issue #738 

```python
# Load env using config.py in root directory
env = grid2op.make(root_path)

# Load env using custom config.py anywhere else
env = grid2op.make(root_path, _config_path="path/to/custom/config.py")
```