### PR TITLE
docs: fix MultiMixEnv docstring referencing step instead of reset

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Work "in progress"
 
 General grid2op improvments:
 
+- fix docstring in MultiMixEnv: "step" should be "reset" (#734)
 - ill formed docstring in the BaseAction module
 - remove pandapower dependency (have a way to install grid2op without pandapower)
 - better logging

--- a/grid2op/Environment/multiMixEnv.py
+++ b/grid2op/Environment/multiMixEnv.py
@@ -84,7 +84,7 @@ class MultiMixEnvironment(GridObjects, RandomObject):
     You might think the MultiMixEnvironment as a dictionary of :class:`Environment` that implements
     some of the :class:`BaseEnv` interface such as :func:`BaseEnv.step` or :func:`BaseEnv.reset`.
 
-    By default, each time you call the "step" function a different mix is used. Mixes, by default
+    By default, each time you call the "reset" function a different mix is used. Mixes, by default
     are looped through always in the same order. You can see the Examples section for information
     about control of these
 


### PR DESCRIPTION
## Summary

The `MultiMixEnv` class docstring incorrectly states that a different mix is used each time the `step` function is called. In practice, the mix rotates on `reset`, not `step` — each `step` call continues within the same mix until the episode ends and `reset` is called again.

This one-word fix corrects the docstring from "step" to "reset" to match the actual behavior.

## Test plan

- Verify the `MultiMixEnv` class docstring now says "reset" instead of "step"
- Confirm the behavior matches: calling `reset()` cycles to the next mix, while `step()` stays in the current mix

Fixes #734
