### PR TITLE
docs: clarify reward kernel flags

### DIFF
--- a/docs/user/reward.rst
+++ b/docs/user/reward.rst
@@ -31,6 +31,13 @@ Customization of the reward
 In grid2op you can customize the reward function / reward kernel used by your agent. By default, when you create an
 environment a reward has been specified for you by the creator of the environment and you have nothing to do:
 
+.. note::
+    In the mathematical MDP notation, the reward kernel is often written as a function of the state,
+    the next state and the action. In grid2op's implementation, reward classes also receive contextual
+    flags such as `has_error`, `is_illegal` and `is_ambiguous`. These flags make it possible to distinguish
+    the original action submitted by the agent from the action effectively applied by the environment, for
+    example when an out-of-bounds redispatching action is replaced by a do-nothing action.
+
 .. code-block:: python
 
     import grid2op


### PR DESCRIPTION
## Summary

- Clarify how Grid2Op reward classes receive contextual flags in addition to the usual MDP reward-kernel inputs.
- Explain that these flags distinguish the agent-submitted action from the action effectively applied by the environment, e.g. when an out-of-bounds redispatching action is replaced by do-nothing.

## Validation

- `git diff --check`
- `python3` content check for the added reward documentation note

Closes #737
